### PR TITLE
Actualizar información sobre las Actas del OMHA

### DIFF
--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -67,7 +67,24 @@
     "url": "https://www.omha.alcoi.org/"
   },
   {
+    "description" : "Este organismos pretende poner en valor el patrimonio natural-ambiental de los casi 500 ríos de Galicia, que funcionará como un órgano de asesoramiento sobre el estado ambiental, económico, social y cultural de los rios.<br/>No ha sido posible encontrar información sobre si el observatorio está activo o no, tampoco sobre su actividad, si la tuviere.",
+    "docs": [
+        {
+            "name": "Diario Oficial de Galicia",
+            "url": "https://www.xunta.gal/dog/Publicados/2018/20180215/AnuncioG0422-080218-0006_es.pdf"
+        },
+        {
+            "name": "La Administración al Día",
+            "url": "https://laadministracionaldia.inap.es/noticia.asp?id=1188617"
+        },
+        {
+            "name": "Galicia Ambiental - Noticia",
+            "url": "https://galiciaambiental.org/es/actualidad-ver/observatorio-dos-rios-de-galicia"
+        }
+    ],
     "name": "Observatorio Autonómico dos Ríos de Galicia",
+    "type": "publico",
+    "from_date": "25-01-2018",
     "scope": "galicia"
   },
   {

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -48,7 +48,7 @@
     "website": "https://www.transportes.gob.es/ferrocarriles/observatorios/observatorio-del-ferrocarril-en-espana"
   },
   {
-    "description": "Se <a href=\"https://www.omha.alcoi.org/wp-content/uploads/2022/03/TEXT-BOP-NUM-137-DE-220720-APROVACIO-DEFINITIVA.pdf\">constituye el 22-07-2020</a>, y a fecha de marzo de 2024 solo se ha reunido en <a href=\"https://www.omha.alcoi.org/es/que-es-omha/\">tres ocasiones</a>. Lamentablemente las actas de sus plenos no se pueden descargar. Tras las elecciones municipales de 2023, parece que el OMHA no ha tenido ninguna actividad.",
+    "description": "Se <a href=\"https://www.omha.alcoi.org/wp-content/uploads/2022/03/TEXT-BOP-NUM-137-DE-220720-APROVACIO-DEFINITIVA.pdf\">constituye el 22-07-2020</a>, y a fecha de marzo de 2024 solo se ha reunido en <a href=\"https://www.omha.alcoi.org/es/actas/\">tres ocasiones</a>. Tras las elecciones municipales de 2023, parece que el OMHA no ha tenido ninguna actividad.",
     "docs": [
       {
         "name": "Plan General de Ordenación Urbana",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -1538,11 +1538,24 @@
     "website": "https://www.consorcioaeronautico.com/observatorio-aeroespacial/gl/"
   },
   {
+    "docs": [
+      {
+        "name": "Decreto 134/2023, de 28 de septiembre, por el que se crea y se regula el Observatorio de la Lusofonía Valentín Paz Andrade",
+        "url": "https://www.xunta.gal/dog/Publicados/2023/20231010/AnuncioG0690-031023-0001_es.html"
+      },
+      {
+        "name": "A Xunta creará o Observatorio da Lusofonía Valentín Paz Andrade para reforzar os lazos entre Galicia e o mundo lusófono",
+        "url": "https://www.xunta.gal/notas-de-prensa/-/nova/83523/xunta-creara-observatorio-lusofonia-valentin-paz-andrade-para-reforzar-los-lazos"
+      }
+    ],
     "description": "El Observatorio tendrá como finalidad asesorar al Gobierno, formular planes de acción y programar actividades de conocimiento, intercambio y programación. Atendiendo a su finalidad, servirá de foro de diálogo permanente entre las distintas administraciones públicas y otras organizaciones representativas de intereses en el ámbito de la lusofonía, a fin de asegurar su participación activa en el abordaje de las relaciones de Galicia en dicho ámbito, así como aglutinará esfuerzos, coordinará las actuaciones público-privadas y procurará la consolidación en el tiempo de Galicia en el mundo de la lusofonía.",
     "from_date": "10/10/2023",
     "is_active": "Sí",
     "name": "Observatorio da Lusofonía Valentín Paz Andrade",
-    "parents": ["Secretaría General de Política Lingüística"],
+    "parents": [
+      "Secretaría General de Política Lingüística",
+      "Xunta de Galicia"
+    ],
     "scope": "galicia",
     "type": "publico"
   },
@@ -1550,7 +1563,11 @@
     "email": "ocj.dretssocials@gencat.cat",
     "is_active": "None",
     "name": "Observatori Català de la Joventut",
-    "parents": ["Agència Catalana de la Joventut"],
+    "parents": [
+      "Agència Catalana de la Joventut",
+      "Departament de Drets Socials",
+      "Generalitat de Catalunya"
+    ],
     "scope": "cataluna",
     "type": "publico",
     "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/joventut/observatori_catala_de_la_joventut/index.html"
@@ -1966,21 +1983,22 @@
     "is_active": "None",
     "name": "Observatori del sistema de salut de catalunya",
     "parents": [
-      "Agència de Qualitat i Avaluació Sanitàries de Catalunya (Generalitat)"
+      "Agència de Qualitat i Avaluació Sanitàries de Catalunya",
+      "Generalitat de Catalunya"
     ],
     "scope": "estatal",
     "type": "publico",
     "website": "https://observatorisalut.gencat.cat/ca/inici"
   },
   {
-    "description": "El Observatorio Tranformación y Participación es un órgano que se constituye para actuar como soporte a la docencia, a la investigación y la participación social. Asentado a nivel autonómico en Castilla y León pretende crear una Red Estatal que aporte soluciones desde la participación social al ámbito de la investigación e innovación aplicada",
+    "description": "El Observatorio Tranformación y Participación es un órgano que se constituye para actuar como soporte a la docencia, a la investigación y la participación social. Asentado a nivel autonómico en Castilla y León pretende crear una Red Estatal que aporte soluciones desde la participación social al ámbito de la investigación e innovación aplicada.",
     "email": "observatoriotransformacion@gmail.com",
     "is_active": "Sí",
     "name": "Observatorio de Transformación y Participación de Castilla y León",
     "parents": ["Junta de Castilla y León"],
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.observatoriotransformacion.com/"
+    "website": "https://www.observatoriotransformacion.com"
   },
   {
     "docs": {
@@ -1989,7 +2007,7 @@
     },
     "is_active": "Sí",
     "name": "Observatori del Treball i Model Productiu",
-    "parents": ["Departament d'Empresa i Treball (Generalitat)"],
+    "parents": ["Departament d'Empresa i Treball", "Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
     "website": "https://observatoritreball.gencat.cat/ca/inici"


### PR DESCRIPTION
He actualizado la URL de su web dónde pueden descargarse las actas.

Tras reclamar las actas, el OMHA ha corregido la URL y ya se pueden descargar. Aún así, la última acta es de 2021.
Según información del propio OMHA, 

> Le informamos que la última convocatoria del Pleno del OHMA tuvo lugar el 24 de marzo de 2022 a las 18h en la sala Àgora. Al ser la última convocatoria celebrada, el acta no está ratificada por los miembros del pleno y por este motivo se encuentra pendiente de publicar. Tras las elecciones, y dado el cambio de Gobierno en las políticas autonómicas, la corporación se está reuniendo con los responsables de las políticas de vivienda a nivel autonómico  para conocer los proyectos que se van a poder ejecutar y que surgían del trabajo de los laboratorios antes de volver a convocar de nuevo al Pleno.
También se está valorando la metodología de este organismo de participación como algo vivo y cambiante según las necesidades del contexto.