### PR TITLE
Añadido scope y cerrado issue 171

### DIFF
--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -1442,6 +1442,7 @@
     "email": "infogen@uvigo.es",
     "is_active": "Sí",
     "name": "Observatorio Municipal Galego",
+    "scope": "galicia",
     "parents": ["Universidade de Vigo", "Xunta de Galicia"],
     "type": "publico",
     "website": "http://www.observatorioredlocalis.com"


### PR DESCRIPTION
Se ha añadio un scope faltante y de paso cerramos la siguiente issue (ya estaba añadido):
https://github.com/JaimeObregon/observatoriospublicos.es/issues/171

```json
 {
    "description": "Imposto sobre Bens Inmobles, Imposto sobre Actividades Económicas, Imposto sobre Vehiculos de Tracción Mecánica, Imposto sobre o Incremento do Valor dos Terreos de Natureza Urbana (Plusvalía muncipal) e o Imposto sobre Instalacións, Construccións e Obras.",
    "email": "infogen@uvigo.es",
    "is_active": "Sí",
    "name": "Observatorio Municipal Galego",
    "scope": "galicia",
    "parents": ["Universidade de Vigo", "Xunta de Galicia"],
    "type": "publico",
    "website": "http://www.observatorioredlocalis.com"
  }
```