### PR TITLE
Evitar el desplazamiento del id del observatorio cuando no se ha definido scope

### DIFF
--- a/httpdocs/modules/observatorioContent.js
+++ b/httpdocs/modules/observatorioContent.js
@@ -54,7 +54,7 @@ function observatoryId(id) {
 }
 
 function observatoryTitle(scope, location) {
-  if (!scope) return ''
+  if (!scope) return '&nbsp;'
   return `
       <span>
         ${scope.key === 'municipal' ? location : scope.name}


### PR DESCRIPTION
Es una chorrada, pero cambia
![image](https://github.com/JaimeObregon/observatoriospublicos.es/assets/1742635/1cdef101-c256-4a96-9b30-59230f7fad64)

por
![image](https://github.com/JaimeObregon/observatoriospublicos.es/assets/1742635/a05f7804-6035-4c17-be15-676f117a9316)

Mientras se rellenan los scope que faltan, que llevará algo más de tiempo...