### PR TITLE
Añadir utilidades Docker para desarrollo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Instala dependencias usando el lockfile existente
+COPY package.json yarn.lock ./
+RUN corepack enable && yarn install --frozen-lockfile
+
+# Copia el resto del código
+COPY . .
+
+# Comando por defecto: ejecutar la verificación de formato con Prettier
+CMD ["yarn", "run", "prettier", "--check", "httpdocs/**/*.{js,json,css}"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "type": "module",
   "main": "httpdocs/index.html",
   "scripts": {
-    "serve": "bin/serve.js"
+    "serve": "bin/serve.js",
+    "docker:watch": "docker run --rm -it -p 8090:8080 -v \"$(pwd)/httpdocs:/app/httpdocs\" observatorios-prettier yarn serve",
+    "docker:validate-obserbatorios": "docker run --rm -v \"$(pwd)\":/work observatorios-prettier sh -c 'cd /work && /app/node_modules/.bin/prettier --check \"httpdocs/**/*.{js,json,css}\"'"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
## Resumen
- Añade Dockerfile con imagen Node 20 para ejecutar Prettier en contenedor
- Expone scripts dockerizados en package.json para servir y validar el catálogo

## Pruebas
- No se ejecutaron pruebas (cambio de tooling)