### PR TITLE
[feature] Añadir coordenadas a observatorios con ubicación

### DIFF
--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -84,6 +84,10 @@
     ],
     "from_date": "2020-07-22",
     "location": "Alcoy",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    },
     "name": "Observatori Municipal de l'Habitatge d'Alcoi",
     "scope": "municipal",
     "type": "publico",
@@ -1353,6 +1357,10 @@
     "is_active": "Si",
     "email": "info@observatoriodalinguagalega.org",
     "location": "Rúa de San Roque, n.º 2 15704 Santiago de Compostela",
+    "coordinates": {
+      "lat": 42.8832409,
+      "lon": -8.5416849
+    },
     "phone": "+34 881 996 302",
     "docs": [
       {
@@ -1492,7 +1500,11 @@
     "website": "https://empleacantabria.es/",
     "is_active": "Si",
     "email": "empleacantabria@cantabria.es",
-    "location": "Paseo General Dávila 87, 39006 Santander"
+    "location": "Paseo General Dávila 87, 39006 Santander",
+    "coordinates": {
+      "lat": 43.4665639,
+      "lon": -3.8145583
+    }
   },
   {
     "name": "Observatorio Español de la Economía Social y del Trabajo Autónomo",
@@ -1790,6 +1802,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Urbano de A Coruña",
     "parents": ["Concello de A Coruña"],
     "scope": "municipal",
@@ -1797,6 +1813,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Municipal de Igualdade e Diversidade",
     "parents": ["Concello de A Coruña"],
     "scope": "municipal",
@@ -1820,6 +1840,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Turístico de A Coruña",
     "parents": ["Concello de A Coruña", "Universidade da Coruña"],
     "scope": "municipal",
@@ -1945,6 +1969,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Urbano de Alcalá de Henares",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1953,6 +1981,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio de Violencia de Género de Alcalá",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1979,6 +2011,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Sociodemográfico del Ayuntamiento de Alcalá de Henares",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1987,6 +2023,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Alcalá en Cifras",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -2648,6 +2688,10 @@
     ],
     "email": "ota@malaga.eu",
     "location": "Málaga",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    },
     "name": "Observatorio Tributario Andaluz",
     "parents": [
       "Ayuntamiento de Málaga",
@@ -5942,6 +5986,10 @@
     "from_date": "2022-07-29",
     "is_active": "Si",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "name": "Observatorio Municipal de Violencia contra las Mujeres (Ayuntamiento de Madrid)",
     "parents": [
       "Ayuntamiento de Madrid",
@@ -5966,6 +6014,10 @@
     "from_date": "2019-03-30",
     "is_active": "Si",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "name": "Observatorio de la Ciudad (Ayuntamiento de Madrid)",
     "parents": [
       "Ayuntamiento de Madrid",
@@ -5987,6 +6039,10 @@
     "from_date": "2017",
     "is_active": "Si",
     "location": "Móstoles",
+    "coordinates": {
+      "lat": 40.3238525,
+      "lon": -3.8649214
+    },
     "name": "Observatorio de la Ciudad de Móstoles (Móstoles Desarrollo)",
     "parents": ["Ayuntamiento de Móstoles", "Móstoles Desarrollo S.A."],
     "scope": "municipal",
@@ -5998,6 +6054,10 @@
     "from_date": "2018-04-18",
     "is_active": "Si",
     "location": "Getafe",
+    "coordinates": {
+      "lat": 40.3070639,
+      "lon": -3.7331808
+    },
     "name": "Observatorio de Gobierno Abierto de Getafe (Observatorio Estadístico Municipal)",
     "parents": [
       "Ayuntamiento de Getafe",
@@ -6019,6 +6079,10 @@
     "from_date": "2015",
     "is_active": "Si",
     "location": "Rivas Vaciamadrid",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    },
     "name": "Observatorio de Ciudad de Rivas Vaciamadrid (Observatorio Urbano RIVAS 2030)",
     "parents": [
       "Ayuntamiento de Rivas Vaciamadrid",
@@ -6748,6 +6812,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Terrassa (Barcelona)",
+    "coordinates": {
+      "lat": 41.5629623,
+      "lon": 2.0100492
+    },
     "website": "https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire"
   },
   {
@@ -6757,6 +6825,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Terrassa (Barcelona)",
+    "coordinates": {
+      "lat": 41.5629623,
+      "lon": 2.0100492
+    },
     "website": "https://www.terrassa.cat/recursos-educatius"
   },
   {
@@ -6865,6 +6937,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Valverde de Burguillos (Badajoz)",
+    "coordinates": {
+      "lat": 38.3273746,
+      "lon": -6.5363287
+    },
     "website": "https://agendaurbanavalverdeburguillos2030.badajoz.es/"
   },
   {
@@ -6881,6 +6957,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Albacete",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    },
     "website": "https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj"
   },
   {
@@ -6902,6 +6982,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default"
   },
   {
@@ -6911,6 +6995,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Algete (Madrid)",
+    "coordinates": {
+      "lat": 40.5961297,
+      "lon": -3.4974479
+    },
     "website": "https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624"
   },
   {
@@ -6920,6 +7008,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Algete (Madrid)",
+    "coordinates": {
+      "lat": 40.5961297,
+      "lon": -3.4974479
+    },
     "website": "https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item"
   }
 ]

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -6970,7 +6970,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2007"
+    "from_date": "2007",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio de Igualdad de la Región de Murcia",
@@ -6991,7 +6995,11 @@
     "website": "https://www.carm.es/web/pagina?IDCONTENIDO=5137&IDTIPO=11&RASTRO=c771$m5828",
     "scope": "region_de_murcia",
     "type": "publico",
-    "from_date": "2003"
+    "from_date": "2003",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio de la Familia de la Región de Murcia",
@@ -7333,7 +7341,11 @@
     ],
     "is_active": "Sí",
     "email": "observatorio@basquetour.eus",
-    "from_date": "2011"
+    "from_date": "2011",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio del sistema de salud de Castilla y León",
@@ -7371,7 +7383,11 @@
     ],
     "is_active": "Sí",
     "email": "info@observatorinatura.cat (general), m.josa@creaf.uab.cat (comunicación)",
-    "from_date": "2023"
+    "from_date": "2023",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio Turístico de la Comunidad de Madrid",
@@ -7406,7 +7422,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2021"
+    "from_date": "2021",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "name": "Observatorio de Enfermedades Raras de la Comunidad de Madrid",
@@ -7416,7 +7436,11 @@
     "type": "publico",
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2025-05-23"
+    "from_date": "2025-05-23",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "name": "Observatori Valencià de Joventut (OVJ)",
@@ -7462,7 +7486,11 @@
       }
     ],
     "is_active": "Sí",
-    "email": "simbiosindustrialcv.ivace@gva.es"
+    "email": "simbiosindustrialcv.ivace@gva.es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio del Sistema Público Valenciano de Servicios Sociales",
@@ -7481,7 +7509,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2023-05-11 (Sesión constituyente)"
+    "from_date": "2023-05-11 (Sesión constituyente)",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio responsabilidad social empresarial  Galicia",
@@ -7863,7 +7895,11 @@
     "parents": ["Diputación de Albacete"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://observatoriosostenibilidad.dipualba.es/"
+    "website": "https://observatoriosostenibilidad.dipualba.es/",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    }
   },
   {
     "name": "Observatorio de la Agenda Rural Sostenible de la provincia de Segovia",
@@ -7907,7 +7943,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Jokoaren Euskal Behatokia",
@@ -7915,7 +7955,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/"
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Turismoaren Euskal Behatokia",
@@ -7923,7 +7967,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/"
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Banda Zabal Ultralasterraren Euskal Behatokia",
@@ -7931,7 +7979,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu"
+    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Euskal Ekintzailetzaren Behatokia (Observatorio Vasco del Emprendimiento)",
@@ -7951,7 +8003,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/"
+    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de la calidad del aire (Terrassa)",
@@ -7984,7 +8040,11 @@
     "description": "Referencia municipal a un observatorio ambiental Litoral-Besòs como recurso externo sobre calidad del aire. <a href=\"https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire\">Enlace</a>.",
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire"
+    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio Valenciano de Salud",
@@ -7992,7 +8052,11 @@
     "parents": ["Generalitat Valenciana"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud"
+    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Euskadiko Osasun Behatokia",
@@ -8000,7 +8064,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/"
+    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Gallego de Salud Pública",
@@ -8008,14 +8076,22 @@
     "parents": ["Xunta de Galicia", "Consellería de Sanidade", "SERGAS"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/"
+    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Metropolitano de Transporte de Granada",
     "description": "Anunciado en septiembre de 2025 como observatorio metropolitano de transporte/movilidad sostenible. <a href=\"https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html\">Fuente</a>.",
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html"
+    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de la Movilidad Metropolitana del CTAZ-USJ",
@@ -8026,7 +8102,11 @@
     ],
     "scope": "aragon",
     "type": "mixto",
-    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/"
+    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio para la Accesibilidad de Gran Canaria",
@@ -8096,7 +8176,11 @@
     "parents": ["Diputación de Castellón"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59"
+    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59",
+    "coordinates": {
+      "lat": 40.2518568,
+      "lon": -0.0615052
+    }
   },
   {
     "name": "Observatorio Urbano de la Agenda Urbana de Valverde de Burguillos",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -3167,7 +3167,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/medioambiente/organos/observatorio-canario-del-cambio-climatico/"
+    "website": "https://www.gobiernodecanarias.org/medioambiente/organos/observatorio-canario-del-cambio-climatico/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "El Observatorio de la Criminalidad Organizada Transnacional (OCOT) es un espacio interdisciplinario, crítico, reflexivo y de formación-acción que congrega una amplia red internacional de profesores e investigadores dedicados al estudio de la criminalidad organizada de modo pormenorizado. Es, además, un ambiente de alto nivel académico-científico y creciente reconocimiento nacional e internacional en la materia, especialmente dado su carácter pionero en el modo con el que aborda la temática estudiada, la calificada producción científica que impulsa, los distintos proyectos de investigación con financiación nacional que le dan cuerpo y la responsabilidad social que caracterizan sus acciones y reflexiones.",
@@ -3216,7 +3220,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www3.gobiernodecanarias.org/sanidad/scs/contenidoGenerico.jsp?idDocument=ba5d4671-60dc-11ed-9e04-cd68079ec7ca&idCarpeta=61e907e3-d473-11e9-9a19-e5198e027117"
+    "website": "https://www3.gobiernodecanarias.org/sanidad/scs/contenidoGenerico.jsp?idDocument=ba5d4671-60dc-11ed-9e04-cd68079ec7ca&idCarpeta=61e907e3-d473-11e9-9a19-e5198e027117",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3265,7 +3273,11 @@
     "parents": ["Universidade de Vigo", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "http://www.observatorioredlocalis.com"
+    "website": "http://www.observatorioredlocalis.com",
+    "coordinates": {
+      "lat": 42.2376602,
+      "lon": -8.7247205
+    }
   },
   {
     "is_active": "Sí",
@@ -3273,7 +3285,11 @@
     "parents": ["Junta de Andalucía"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/observatorio-andaluz-de-publicidad-no-sexista"
+    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/observatorio-andaluz-de-publicidad-no-sexista",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de la Comunidad de Madrid contra el Racismo y la Intolerancia",
@@ -3358,7 +3374,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.ajsosteniblebcn.cat/ca/observatori-a-s_99532"
+    "website": "https://www.ajsosteniblebcn.cat/ca/observatori-a-s_99532",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Realización de eventos y actos de difusión de los resultados de los estudios realizados.",
@@ -3566,7 +3586,11 @@
     "stop_date": "a dìa de hoy sigue funcionando. Publica algunas excel con datos hasta al menos 2023",
     "type": "publico",
     "email": "oscn@navarra.es",
-    "website": "https://portalsalud.navarra.es/es/observatorio"
+    "website": "https://portalsalud.navarra.es/es/observatorio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": [
@@ -3679,7 +3703,11 @@
     "name": "Observatorio Andaluz de Violencia de Género",
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/2013-08-08-10-31-21/observatorio-andaluz-de-violencia-de-genero"
+    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/2013-08-08-10-31-21/observatorio-andaluz-de-violencia-de-genero",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "L’Observatori de salut i impacte de polítiques (OBSIP) és una eina que permet fer un seguiment: (1) de l’estat de la salut a la ciutat i de les desigualtats existents entre barris i grups socials i (2) de l’impacte en salut de determinades polítiques dutes a terme per l’Ajuntament.",
@@ -3692,7 +3720,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://ajuntament.barcelona.cat/observatorisalut"
+    "website": "https://ajuntament.barcelona.cat/observatorisalut",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Grupo de trabajo, consultivo, asesor y de colaboración entre la administración de la Junta de Comunidades de Castilla-La Mancha y las organizaciones representativas del comercio, del ámbito de la economía digital, y las organizaciones más representativas de las personas trabajadoras del sector, que servirá para dar apoyo a los actores implicados en la comprensión de las dinámicas del comercio regional y afrontar nuevos retos.",
@@ -3771,7 +3803,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://iam.asturias.es/observatorio-de-igualdad-de-oportunidades"
+    "website": "https://iam.asturias.es/observatorio-de-igualdad-de-oportunidades",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatori de l'economia local de Sabadell",
@@ -3791,7 +3827,11 @@
     "description": "La sociedad cambia constantemente y una administración responsable necesita herramientas que permitan vigilar este cambio, medir la eficiencia de las medidas adoptadas, descubrir los problemas y las oportunidades de mejora. Para vigilar esta transformación, mejorar en la toma de decisiones y por transparencia, decidimos crear el OBSERVATORIO DE TRANSFORMACIÓN DIGITAL DE NAVARRA.\n\nEn este espacio compartiremos los principales indicadores de transformación digital de nuestra comunidad en los ejes de [personas](https://observatoriotransformaciondigital.navarra.es/es/personas), [gobierno](https://observatoriotransformaciondigital.navarra.es/es/gobierno), [empresas](https://observatoriotransformaciondigital.navarra.es/es/empresas) e [infraestructuras](https://observatoriotransformaciondigital.navarra.es/es/infraestructuras), así como otras [acciones](https://observatoriotransformaciondigital.navarra.es/es/acciones) relacionadas.\n\nEstos datos nos darán una medida del progreso de Navarra, comparándola, siempre que exista el dato, con España y Europa.",
     "scope": "autonómico",
     "parents": ["Gobierno de Navarra - Nafarroako Gobernua"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio de Servicios Sociales y Dependencia se configura como un órgano colegiado, de composición interdepartamental, con funciones asesoras, de investigación, formación y trasferencia del conocimiento en materia de servicios sociales y dependencia; que ejercerá sus funciones con plena autonomía y sin dependencia funcional de ningún órgano. El Observatorio pretende contribuir también a la reflexión y mejora de la práctica profesional, promoviendo el trabajo interdisciplinar, un buen clima laboral que cuide a las personas cuidadoras, la agilización y simplificación de trámites, la formación continua, así como la evaluación de procesos y resultados.",
@@ -3871,7 +3911,11 @@
         "name": "Observatorio económico mensual de la provincia de Jaén"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.9553976,
+      "lon": -3.4937431
+    }
   },
   {
     "email": "info@fepa18.org",
@@ -4080,7 +4124,11 @@
     "parents": ["Ayuntamiento de Madrid"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Observatorio-de-la-Ciudad/?vgnextfmt=default&vgnextchannel=ec38d941c9b25710VgnVCM2000001f4a900aRCRD"
+    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Observatorio-de-la-Ciudad/?vgnextfmt=default&vgnextchannel=ec38d941c9b25710VgnVCM2000001f4a900aRCRD",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Este Observatorio tiene sobre la mesa los retos identificados para la industria en la región: el crecimiento de la internacionalización de un sector que es responsable de uno de cada tres euros de las exportaciones de la Comunidad Autónoma, así como la digitalización, la sostenibilidad y la innovación en la industria.",
@@ -4156,7 +4204,11 @@
     "parents": ["Ayuntamiento de Badajoz"],
     "stop_date": "El último informe es de 2015",
     "type": "publico",
-    "website": "https://www.aytobadajoz.es/es/empleo/estudios-y-estadisticas/observatorio-del-cambio"
+    "website": "https://www.aytobadajoz.es/es/empleo/estudios-y-estadisticas/observatorio-del-cambio",
+    "coordinates": {
+      "lat": 38.878187,
+      "lon": -6.9701115
+    }
   },
   {
     "description": "Es una herramienta de información permanente y actual sobre el mercado de trabajo de la región, que nace con el objetivo de orientar sobre las demandas de empleo y formativas que surjan en determinados momentos y puntos de la comunidad autónoma.",
@@ -4391,7 +4443,11 @@
     "name": "Observatorio del Cambio Climático / Observatori del Canvi Climàtic",
     "parents": ["Ayuntamiento de Valencia"],
     "type": "publico",
-    "website": "https://climaienergia.com/observatori/"
+    "website": "https://climaienergia.com/observatori/",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "El Observatorio de CPR de Canarias es un órgano de asesoramiento, control y estudio respecto a la contratación pública para la sociedad civil y agentes involucrados.",
@@ -4513,7 +4569,11 @@
     "parents": ["Ayuntamiento de Málaga"],
     "scope": "local",
     "type": "publico",
-    "website": "https://movilidad.malaga.eu/es/lineas-de-trabajo/movima/"
+    "website": "https://movilidad.malaga.eu/es/lineas-de-trabajo/movima/",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    }
   },
   {
     "description": "Es un órgano colegiado adscrito a la Concejalía de Bienestar Social del Ayuntamiento de Fuenlabrada, cuya misión es convertirse en referente para la medición, seguimiento, evaluación, análisis y difusión de información sobre el desarrollo de la Ley 39/2006, de 14 de diciembre, de Promoción de la Autonomía Personal y Atención a las personas en situación de dependencia.\n\nEl Observatorio, recopila y difunde el conjunto de conocimientos, experiencias y buenas prácticas, ofreciendo una visión global y permanente de la situación y evolución de la Ley, que permite evaluar su impacto y el cumplimiento del mapa de recursos y servicios que determina, así como trasladar a otras administraciones la información que mejore la aplicación de la citada Ley.\n\nFunciones del Observatorio\n\n1. Constituir una base de información que pueda dar cuenta de la situación de la aplicación de la Ley a nivel local.\n\n2. Analizar las nuevas tendencias y cambios que se vayan produciendo en la aplicación de la Ley y factores asociados.\n\n3. Realizar investigaciones y estudios preparatorios y de viabilidad, organizar reuniones de técnicos y usuarios, y crear, si fuera necesario grupos de trabajo.\n\n4. Difundir los procesos anteriores y elaborar publicaciones e informes de carácter periódico sobre la temática.\n\n5. Facilitar el intercambio de información sobre la aplicación de la Ley con otros municipios y agentes sociales como empresas del sector, vecinos, técnicos, sindicatos, partidos políticos.\n\n6. Proponer un mapa de recursos lo que supondrá una mayor apuesta por la calidad.",
@@ -4572,7 +4632,11 @@
       "Área de Turismo de Málaga"
     ],
     "type": "publico",
-    "website": "https://visita.malaga.eu/profesional/es/observatorio-turistico"
+    "website": "https://visita.malaga.eu/profesional/es/observatorio-turistico",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    }
   },
   {
     "description": "Es una entidad dedicada a la recopilación y análisis de datos sobre la movilidad en Cataluña, abarcando aspectos como el transporte de personas y mercancías, sostenibilidad, infraestructuras y economía del transporte. Su objetivo es proveer información útil y servir como foro de análisis para atender las necesidades de sus usuarios.",
@@ -4739,7 +4803,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://www.castillalamancha.es/gobierno/agriaguaydesrur/estructura/dgalimentacion/titular/observatorio-precios-cadena-agroalimentaria"
+    "website": "https://www.castillalamancha.es/gobierno/agriaguaydesrur/estructura/dgalimentacion/titular/observatorio-precios-cadena-agroalimentaria",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Facilita que las personas consumidoras tomen decisiones de compra informadas con arreglo a criterios económicos.",
@@ -4783,14 +4851,22 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://consumo.castillalamancha.es/node/23956"
+    "website": "https://consumo.castillalamancha.es/node/23956",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "is_active": "None",
     "name": "Observatorio Aragonés de Dinamización Demográfica y Poblacional",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://observatoriopoblacion.aragon.es/"
+    "website": "https://observatoriopoblacion.aragon.es/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -4808,7 +4884,11 @@
     "name": "Observatorio Aragonés por la Convivencia y Contra el Acoso Escolar",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://educa.aragon.es/-/convivencia-web-basico-enlaces"
+    "website": "https://educa.aragon.es/-/convivencia-web-basico-enlaces",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -4816,7 +4896,11 @@
     "parents": ["Universidad de Zaragoza"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://oaaep.unizar.es/"
+    "website": "https://oaaep.unizar.es/",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "description": "El objetivo de este proyecto es no solo identificar, cartografiar y perfilar los desiertos alimentarios y de ejercicio físico en zonas rurales, si no también definir el concepto de desierto rural de ejercicio físico, explorar estrategias para mejorar la salud y el bienestar de las personas que viven en zonas rurales, y colaborar con las comunidades, empresas y servicios para abordar las inequidades que sufren las personas que viven en áreas rurales despobladas, desatendidas y, a menudo, desfavorecidas. Los resultados de esta investigación serán publicados a través del Observatorio Europeo de Desiertos Alimentarios y de Ejercicio Físico en Zonas Rurales.\n\nEl proyecto DESERT, con un presupuesto total de 638.591€, ha sido cofinanciado por la Unión Europea a través del programa E4Health Partnership y durará 3 años (2024-2027). Ambos socios reciben fondos del Instituto de Salud Carlos III, a través de la AES 2023, con código AC23_2/00039 y AC23_2/00003 en el marco de Partnership Fostering a European Research Area for Health (ERA4Health) GA nº 101095426 del Programa de Investigación e Innovación Horizonte Europa de la Unión Europea.\n\nNoticias sobre la creación de un Observatorio Europeo de Desiertos Rurales Alimentarios y de Ejercicio Físico:\r\n1. [Universidad de Zaragoza](https://ucc.unizar.es/noticia/aragon-impulsara-la-creacion-de-un-observatorio-europeo-de-desiertos-rurales-alimentarios-y)\r\n2. [Heraldo de Aragón](https://www.heraldo.es/noticias/aragon/2024/05/13/aragon-impulsara-creacion-observatorio-europeo-desiertos-rurales-alimentarios-ejercicio-fisico-1733325.html)\r\n3. [Agenda de la reunión (PDF)](https://www.iisaragon.es/wp-content/uploads/2024/05/DESERT-Kick-off.pdf)\n\n- Universidad de Zaragoza (pública)\r\n- Instituto de Investigación Sanitaria de Aragón (IISA) ([pública](https://contrataciondelestado.es/wps/poc?uri=deeplink%3AperfilContratante&idBp=%2F5d2hWOr17umq21uxhbaVQ%3D%3D))",
@@ -4848,7 +4932,11 @@
     "parents": ["Gobierno de Canarias", "Dirección General de Juventud"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/juventud/programas/observatorio-canario-de-la-juventud/"
+    "website": "https://www.gobiernodecanarias.org/juventud/programas/observatorio-canario-de-la-juventud/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "from_date": "2011",
@@ -4923,7 +5011,11 @@
         "name": "En las memorias, se especifican https://observatoridesc.org/es/transparencia"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "docs": [
@@ -5046,7 +5138,11 @@
     "parents": ["Cabildo de Tenerife"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.deportestenerife.es/oficina-virtual/observatorio-de-la-bicicleta/"
+    "website": "https://www.deportestenerife.es/oficina-virtual/observatorio-de-la-bicicleta/",
+    "coordinates": {
+      "lat": 43.4934282,
+      "lon": -3.5689291
+    }
   },
   {
     "is_active": "None",
@@ -5169,7 +5265,11 @@
     "name": "Observatorio de la Escuela Rural de Aragón",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://educa.aragon.es/-/innovacion/observatorio-rural"
+    "website": "https://educa.aragon.es/-/innovacion/observatorio-rural",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -5204,7 +5304,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/estudios-1"
+    "website": "https://www.aragon.es/-/estudios-1",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio para la Innovación de los Informativos en la Sociedad Digital",
@@ -5335,7 +5439,11 @@
     "parents": ["Junta de Andalucía"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.sspa.juntadeandalucia.es/servicioandaluzdesalud/todas-noticia/constituido-el-observatorio-de-agresiones-profesionales-del-sistema-sanitario-publico"
+    "website": "https://www.sspa.juntadeandalucia.es/servicioandaluzdesalud/todas-noticia/constituido-el-observatorio-de-agresiones-profesionales-del-sistema-sanitario-publico",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "is_active": "None",
@@ -5425,7 +5533,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-aragones-de-familia"
+    "website": "https://www.aragon.es/-/observatorio-aragones-de-familia",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "El Observatorio tratará de desarrollar tres líneas fundamentales: generar un espacio de conocimiento sobre la información en salud en Asturias a través de una serie de informes periódicos; garantizar que esta información llegue de la forma más comprensible al mayor número de agentes de salud posibles, destacando la importancia de un abordaje de los determinantes sociales de la salud y, finalmente, vincular la información en salud de los indicadores a las diferentes actuaciones comunitarias en salud que se están desarrollando en Asturias.\n\nDirección General de Salud Pública. Consejería de Sanidad. Gobierno del Principado de Asturias.\r\nSupervisión: School of Public Health and Medicine de la Universidad de Wisconsin-Madison.",
@@ -5570,7 +5682,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.educantabria.es/diversidad/convivencia"
+    "website": "https://www.educantabria.es/diversidad/convivencia",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "El Observatorio de la cuenca Saja-Besaya, denominado Observatorio SABE, es un órgano independiente, de carácter técnico y multidisciplinar, que trabaja por implementar mejoras en nuestros ecosistemas, paisajes, estuarios, zonas forestales o urbanas, entre otras.\n\nConsejo Asesor:\n\n> El Consejo Asesor está compuesto por Soledad Nogués, profesora titular de Urbanística y Ordenación del Territorio de la Universidad de Cantabria y Torrelaveguense ilustre 2016, Jesús Tortosa, Director General de la Cámara de Comercio de Cantabria, Leandro Morante, exdirector del CIMA de Torrelavega, Sonsoles Pérez, Jefa de seguridad, higiene, medio ambiente y calidad de Solvay, Felipe González, delegado en Cantabria de SEO Birdlife, y Fernando Isasi, Director gerente de la Red Cántabra de Desarrollo Rural.\n\nConsejo Rector:\n\n>  14 personas (6 de las entidades incorporadas, 6 del Consejo Asesor y 2 de la secretaría y dirección).",
@@ -5589,7 +5705,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://observatoriosabe.es"
+    "website": "https://observatoriosabe.es",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "La confianza de los ciudadanos en las instituciones públicas se gana con dificultad y se pierde fácilmente. Lo ideal es que las instituciones públicas actúen de manera socialmente responsable y ética para ganar y mantener la confianza de los ciudadanos en las instituciones públicas y políticas.\n\nLos ciudadanos activos son cruciales en la lucha contra la corrupción: llaman la atención sobre la gravedad de este problema, elevan la conciencia pública sobre su impacto, y actúan como vigilantes efectivos de cargos públicos y partidos monitorizándolos y manteniéndolos bajo un escrutinio constante en términos de rendición de cuentas y capacidad de respuesta. Esto conduce poco a poco a un mecanismo de autocontrol, ya que obliga a los cargos y funcionarios públicos a comportarse éticamente y ofrecer un gobierno limpio. Por el contrario, altos niveles de percepción de mala gobernanza o corrupción, conducen a la frustración de los ciudadanos con su sector público, a la apatía pública, a la falta de compromiso cívico y a la falta de confianza en el proceso político y democrático, y finalmente también al aumento del fraude fiscal, que es la otra cara de la misma moneda.\n\nLa Convención de las Naciones Unidas contra la Corrupción (UNCAC) proporciona la base para la participación ciudadana en los esfuerzos anticorrupción en el artículo 13, que obliga a los Estados miembros a «tomar las medidas adecuadas para promover la participación activa de individuos y grupos ajenos al sector público, como la sociedad civil, las organizaciones no gubernamentales y las organizaciones comunitarias, en la prevención y la lucha contra la corrupción «, y exige a los Estados miembros que proporcionen vías de participación pública en la toma de decisiones.\n\nEste Observatorio pretende contribuir dentro de sus posibilidades, a esta participación activa de la ciudadanía a favor de la transparencia en el diseño de las políticas públicas, y de la integridad en su ejecución.\n\nundefined",
@@ -5735,7 +5855,11 @@
     ],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://www.casaarabe.es/eventos-arabes/show/observatorio-de-finanzas-islamicas-en-espana"
+    "website": "https://www.casaarabe.es/eventos-arabes/show/observatorio-de-finanzas-islamicas-en-espana",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El “Observatorio Agenda Provincia de Cáceres” se concibe con el objetivo de integrar de forma estructurada tanto la información socioeconómica, como la generada en las distintas acciones incluidas en el Plan de Acción de Diputación de Cáceres.\n\nEste observatorio permitirá realizar el seguimiento de la evolución de los indicadores registrados actualmente y de aquellos que se incorporen durante la consecución de las acciones incluidas en el Plan de Acción de Diputación de Cáceres, constituyendo una herramienta fundamental tanto para las tareas de planificación de Diputación de Cáceres como para la transferencia de resultados a la ciudadanía.",
@@ -5817,7 +5941,11 @@
     "parents": ["Ayuntamiento de Alcoy"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.alcoyturismo.com/pag/4174/observatorio-turistico.html"
+    "website": "https://www.alcoyturismo.com/pag/4174/observatorio-turistico.html",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    }
   },
   {
     "is_active": "Si",
@@ -5859,7 +5987,11 @@
     "parents": ["Instituto De Seguridade E Saúde Laboral De Galicia - Issga"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://issga.xunta.gal/gl/observatorio"
+    "website": "https://issga.xunta.gal/gl/observatorio",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Nacional del Software de Fuentes Abiertas (ONSFA)",
@@ -5969,7 +6101,11 @@
       {
         "url": "https://www.valencia.es/documents/d/guest/informe-tasa-de-paro-agosto-2025-pdf"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "Este Observatorio tiene como objetivo proporcionar claves sobre la calidad del sistema universitario español que puedan contribuir a la reflexión de diversos agentes interesados para la mejora de la calidad del mismo.",
@@ -6030,7 +6166,11 @@
     "parents": ["Ayuntamiento de Alcoy"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.alcoi.org/es/areas/sanidad/bienestar_animal/observatorio_proteccion.html"
+    "website": "https://www.alcoi.org/es/areas/sanidad/bienestar_animal/observatorio_proteccion.html",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    }
   },
   {
     "is_active": "Si",
@@ -6085,7 +6225,11 @@
     "parents": ["Ayuntamiento de Albacete"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.albacete.es/es/empleo-promocion-economica/empleo/observatorio-empleo"
+    "website": "https://www.albacete.es/es/empleo-promocion-economica/empleo/observatorio-empleo",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    }
   },
   {
     "description": "El Observatorio Social de Álava se crea precisamente como una herramienta de información complementaria sobre la actividad de los Servicios Sociales en el Territorio Histórico. A través de esta web, la Diputación Foral de Álava pretende poner a disposición de los técnicos que trabajan en el área de Bienestar Social y de la ciudadanía en general un núcleo de datos estadísticos que permitan:\nConocer las principales magnitudes de la red alavesa de Servicios Sociales.\nRealizar comparaciones entre diferentes cuadrillas y/o municipios.\nValorar la adecuación de los recursos disponibles a las necesidades presentes en el Territorio Histórico.\nEvaluar la adecuación de los servicios en referencia a una serie de estándares de buena práctica.\nRealizar un seguimiento de la evolución de los Servicios Sociales en el Territorio Histórico.",
@@ -6158,7 +6302,11 @@
     ],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-aragones-de-consumo"
+    "website": "https://www.aragon.es/-/observatorio-aragones-de-consumo",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Para <q>recabar la información necesaria sobre el turismo y ponerla a disposición de la industria turística del territorio para que esta pueda tomar las decisiones más adecuadas y anticiparse a los retos del sector</q>",
@@ -6174,7 +6322,11 @@
     "parents": ["Ayuntamiento de València"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.valencia.es/cas/actualidad/-/content/observatorio-social-1"
+    "website": "https://www.valencia.es/cas/actualidad/-/content/observatorio-social-1",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "Es <q>el órgano que de una manera estructurada y planificada recoge, gestiona, procesa y genera estudios relacionados con el ámbito de la juventud</q>.",
@@ -6229,7 +6381,11 @@
     "parents": [
       "Consejería de Presidencia, Reto Demográfico, Igualdad y Turismo (Gobierno de Asturias)"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Creado en 2016, está constituido por un grupo de trabajo cuya finalidad es el estudio, la investigación, la formación, la divulgación, la promoción y la elaboración de estrategias para la Cooperación para el Desarrollo y la Educación para la Ciudadanía Global en la provincia de Zaragoza.",
@@ -6261,7 +6417,11 @@
     "parents": ["Gobierno de Cantabria"],
     "scope": "cantabria",
     "type": "publico",
-    "website": "https://www.cantabria.es/web/comunicados/w/el-gobierno-creará-un-observatorio-de-transición-generacional-para-afrontar-el-mayor-desafío-al-que-se-enfrenta-el-sector-agrario-de-cantabria"
+    "website": "https://www.cantabria.es/web/comunicados/w/el-gobierno-creará-un-observatorio-de-transición-generacional-para-afrontar-el-mayor-desafío-al-que-se-enfrenta-el-sector-agrario-de-cantabria",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "name": "Observatorio de tecnología educativa",
@@ -6332,7 +6492,11 @@
       {
         "url": "https://www.valencia.es/documents/20142/52352/Folleto%2520OMAV%2520cas-1.pdf/7260ab13-d095-c0c0-dc1b-4bde87943718"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio de Sostenibilidad Turística de Galicia",
@@ -6374,7 +6538,11 @@
     "scope": "aragon",
     "parents": ["Instituto Aragonés de Empleo (INAEM)"],
     "is_active": "Si",
-    "description": "El Observatorio de Mercado de Trabajo del INAEM es un servicio público de información y análisis del mercado de trabajo en Aragón, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio de Mercado de Trabajo del INAEM es un servicio público de información y análisis del mercado de trabajo en Aragón, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio mercado de trabajo",
@@ -6383,7 +6551,11 @@
     "scope": "asturias",
     "parents": ["Gobierno del Principado de Asturias"],
     "is_active": "Si",
-    "description": "El Observatorio de Mercado de Trabajo del Principado de Asturias es un servicio público de información y análisis del mercado de trabajo en Asturias, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio de Mercado de Trabajo del Principado de Asturias es un servicio público de información y análisis del mercado de trabajo en Asturias, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
@@ -6632,7 +6804,11 @@
     "type": "publico",
     "website": "https://www.dipusevilla.es/la-diputacion/areas/area-de-cohesion-social-e-igualdad/Servicio-de-Igualdad-y-Diversidad/observatorio-para-la-igualdad-y-la-diversidad/el-observatorio/",
     "is_active": "Sí",
-    "email": "No disponible"
+    "email": "No disponible",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio de Transición Justa de Asturias (OTJA)",
@@ -6690,7 +6866,11 @@
     "from_date": "Anunciado el 30 / diciembre/ 2024.",
     "parents": [
       "Consejo Extremeño de Promoción de la Accesibilidad Universal de laJunta de Extremadura."
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Violencia Machista en Bizkaia",
@@ -6875,7 +7055,11 @@
     ],
     "is_active": "Sí",
     "email": "observatorijove@gva.es",
-    "from_date": "Ley 15/2017 de la Generalitat"
+    "from_date": "Ley 15/2017 de la Generalitat",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatori Simbiosi Industrial de la Comunitat Valenciana (OSICV)",
@@ -6978,7 +7162,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2011"
+    "from_date": "2011",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Permanente",
@@ -7049,7 +7237,11 @@
     "scope": "barcelona",
     "type": "publico",
     "website": "https://ajuntament.barcelona.cat/dretssocials/ca/content/observatori-social-bcn",
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Bilbao Observatorio (Bilbao Ekintza)",
@@ -7088,7 +7280,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2021"
+    "from_date": "2021",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatori del Canvi Climàtic (Valencia)",
@@ -7217,7 +7413,11 @@
     "scope": "local",
     "type": "publico",
     "is_active": "No",
-    "from_date": "2024-01-09 (Propuesto)"
+    "from_date": "2024-01-09 (Propuesto)",
+    "coordinates": {
+      "lat": 40.3281942,
+      "lon": -3.76527
+    }
   },
   {
     "name": "Observatorio de la Movilidad de Rivas-Vaciamadrid",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -36,7 +36,11 @@
     "parents": ["Diputación de Granada"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://opaugranada.es/"
+    "website": "https://opaugranada.es/",
+    "coordinates": {
+      "lat": 37.1734995,
+      "lon": -3.5995337
+    }
   },
   {
     "docs": [
@@ -182,11 +186,19 @@
     "from_date": "25-01-2018",
     "name": "Observatorio Autonómico dos Ríos de Galicia",
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Sociedade da Información e a Modernización de Galicia",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Violencia no Contorno Laboral",
@@ -219,7 +231,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://oteagranada.com/"
+    "website": "https://oteagranada.com/",
+    "coordinates": {
+      "lat": 37.1734995,
+      "lon": -3.5995337
+    }
   },
   {
     "description": "Es una entidad que supervisa y reporta el progreso y estado de la administración electrónica en España. Publica mensualmente un boletín con indicadores clave, recolectando datos propios y de terceros para ofrecer una visión completa del desarrollo y avance de la digitalización de los servicios administrativos en el país. Su función principal es proporcionar información actualizada y relevante que ayude en la transformación digital y mejora de la administración electrónica.",
@@ -318,7 +334,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://observatoricullera.uv.es/"
+    "website": "https://observatoricullera.uv.es/",
+    "coordinates": {
+      "lat": 39.1647217,
+      "lon": -0.2542313
+    }
   },
   {
     "name": "Observatorio de la Infancia de España",
@@ -354,7 +374,11 @@
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de Asturias",
-    "scope": "asturias"
+    "scope": "asturias",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatorio de Políticas del Agua (OPPA)",
@@ -498,7 +522,11 @@
     ],
     "scope": "cantabria",
     "type": "publico",
-    "website": "https://fmvaldecilla.es/unidad/observatorio-de-salud-publica-de-cantabria/"
+    "website": "https://fmvaldecilla.es/unidad/observatorio-de-salud-publica-de-cantabria/",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "Nace <q>como un órgano colegiado intersectorial para apoyar el análisis, diagnóstico, evaluación y seguimiento de los efectos de la emergencia climática en la salud, al tiempo que ofrece apoyo científico-técnico a las Administraciones públicas</q>.",
@@ -594,7 +622,11 @@
     "name": "Observatorio do Sector Lácteo de Galicia",
     "scope": "galicia",
     "type": "publico",
-    "website": "https://fogga.xunta.gal/es/sector_lacteo/observatorio_del_sector_lacteo"
+    "website": "https://fogga.xunta.gal/es/sector_lacteo/observatorio_del_sector_lacteo",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "docs": [
@@ -651,7 +683,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://occet.es/"
+    "website": "https://occet.es/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio Español contra la LGBTfobia"
@@ -795,7 +831,11 @@
     ],
     "scope": "autonómico",
     "type": "mixto",
-    "website": "https://www.odina.es"
+    "website": "https://www.odina.es",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatorio Estatal de la Dependencia",
@@ -1085,7 +1125,11 @@
     "parents": ["Consejo Social UPM"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.upm.es/observatorio/vi/index.jsp"
+    "website": "https://www.upm.es/observatorio/vi/index.jsp",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio para el Análisis y Visibilidad de la Exclusión Social , nace con el propósito de investigar situaciones, procesos y estructuras de exclusión social, darles visibilidad con campañas de comunicación y crear proyectos de intervención para colaborar en su erradicación. Se materializa así, como una manifestación más de la responsabilidad social universitaria, el firme compromiso de la Universidad Rey Juan Carlos en apostar por la igualdad de todas las personas, así como en la generación de oportunidades vitales para ellas. Este Observatorio está formado por un grupo interdisciplinar de PDIs, liderados desde la Sociología (investigación social) y el Trabajo Social (intervención social) de esta Universidad. Por su parte, el Grupo IDEX, líder en comunicación social, será el socio externo que implementaría la estrategia de difusión y sensibilización de la realidad investigada, financiándose a través de RSC de empresas. Se une la Universidad y la sociedad civil en la mejora de la calidad de vida de las personas más vulnerables.\n\nOBJETIVOS:\n\nInvestigar y analizar situaciones, procesos y estructuras de exclusión social.\r\nLanzar campañas mediáticas para sensibilizar a la sociedad en general, de las situaciones, procesos y estructuras de exclusión social previamente estudiadas.\r\nGenerar proyectos de intervención social para los fenómenos analizados.",
@@ -1221,7 +1265,11 @@
     "scope": "local",
     "to_date": "Continúa",
     "type": "publico",
-    "website": "https://www.alicante.es/es/gobierno-abierto/transparencia/conceptos/observatorio-calidad-servicios-municipales"
+    "website": "https://www.alicante.es/es/gobierno-abierto/transparencia/conceptos/observatorio-calidad-servicios-municipales",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "name": "Observatorio Tecnológico",
@@ -1243,7 +1291,11 @@
         "name": "Informe de Transformación Urbana de Sevilla 2022"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio Territorial de Andalucía",
@@ -1295,7 +1347,11 @@
     "parents": [
       "Consellería de presidencia, Xustiza e Deportes",
       "Xunta de Galicia"
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "1. Este observatorio, para a consecución dos seus fins, exercerá as seguintes funcións:\n\na) Actuar como órgano de recompilación, análise e intercambio da información dispoñible en diferentes fontes autonómicas, estatais e internacionais sobre a familia e os nenos, nenas e adolescentes.\n\nb) Propoñer a realización de estudos, investigacións e informes técnicos que permitan un mellor coñecemento da situación da familia e da infancia en Galicia e a detección das súas necesidades e demandas sociais.\n\nc) Avaliar o impacto das políticas fiscais, laborais e sociais desenvolvidas polos distintos departamentos das administracións na situación das familias e da infancia galegas.\n\nd) Formular propostas e recomendacións sobre liñas estratéxicas e prioridades de actuación en materia de políticas familiares e de infancia no ámbito da Comunidade Autónoma Galega.\n\ne) Servir de canle para a actuación coordinada e harmónica entre os distintos departamentos das administracións públicas no ámbito da familia e a infancia.\n\nf) Canalizar as propostas das organizacións sociais que desenvolven as súas actividades no ámbito da familia e da infancia.\n\ng) Promover as actuacións necesarias para sensibilizar a toda a cidadanía no coñecemento e respecto dos dereitos da infancia en Galicia e no mundo.\n\nh) Promover a elaboración e desenvolvemento dos plans e estratexias de familia, de infancia e adolescencia e avaliar a súa execución.\n\ni) Elaborar informes e ditames por petición dos órganos competentes da Comunidade Autónoma sobre as materias da súa competencia.\n\nj) Impulsar a incorporación da perspectiva da familia e infancia no ordenamento xurídico galego, de xeito que se tomen en consideración as necesidades da infancia, da adolescencia e das familias galegas.\n\nk) Participar, elevar propostas e manter contactos con outros órganos de similar natureza, promovendo os encontros entre profesionais e persoas expertas, tanto no ámbito autonómico e estatal como internacional, para facilitar o intercambio de experiencias, investigacións e traballos nesta materia.\n\n2. No exercicio das funcións establecidas neste artigo terase en conta e integrarase de xeito transversal a perspectiva de xénero e a relación recíproca entre familia e infancia e igualdade de xénero.\n\ntitular da consellería competente en materia de familia\r\n titular da dirección xeral competente en materia de familia\r\n funcionaria da consellería competente en materia de familia\r\n persoa en representación do órgano competente en materia de estatística\r\npersoa en representación da Delegación do Goberno en Galicia\r\npersoa en representación da Federación Galega de Municipios e Provincias (Fegamp)\r\npersoa en representación de cada unha das tres universidades galegas\r\npersoa representante da Fiscalía da Comunidade Autónoma de Galicia\r\nUn número de persoas equivalente ao de representantes sindicais en representación da Confederación de Empresarios de Galicia (CEG)\r\npersoa en representación de cada unha das organizacións sindicais intersectoriais máis representativas de Galicia, así como das presentes na Mesa Xeral de Negociación das Administracións Públicas que non teñan a condición de máis representativas\r\npersoa representante da Plataforma de Organizacións da Infancia de Galicia (POI Galicia)\r\npersoa en representación da Fundación UNICEF-Comité Español",
@@ -1366,7 +1422,11 @@
     ],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.observatoriodavivenda.gal"
+    "website": "https://www.observatoriodavivenda.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Lingua Galega",
@@ -1570,7 +1630,11 @@
         "name": "La Diputación de Badajoz pone a disposición una plataforma online interactiva con datos socioeconómicos de la provincia",
         "url": "https://www.dip-badajoz.es/agenda/index.php?id=3&agenda=21524"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 38.878187,
+      "lon": -6.9701115
+    }
   },
   {
     "name": "Observatorio Ocupacional y Empresarial de ILDEFE",
@@ -1677,7 +1741,11 @@
     "parents": ["Gobierno de la Región de Murcia"],
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=740&IDTIPO=140"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=740&IDTIPO=140",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de Turismo de Extremadura",
@@ -1751,7 +1819,11 @@
         "name": "Orden de 1 de febrero de 2007 de la Consejería de Sanidad por el que se crea el Observatorio sobre Drogas de la Región de Murcia.",
         "url": "https://www.murciasalud.es/-/legislacion-97389"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatori Balear de la Societat de la Informació (OBSI)",
@@ -1876,7 +1948,11 @@
     "parents": ["Universidad de Vigo"],
     "scope": "autonómico",
     "type": "mixto",
-    "website": "observatorio.eolico.uvigo.es"
+    "website": "observatorio.eolico.uvigo.es",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "location": "A Coruña",
@@ -2005,7 +2081,11 @@
     "parents": [
       "Consellería de Cultura, Lengua y Juventud de la Xunta de Galicia"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "location": "Alcalá de Henares",
@@ -2250,7 +2330,11 @@
       {
         "name": "Encuesta continua del Observatorio Turístico de la Provincia de Sevilla"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio para la Prevención del Tabaquismo",
@@ -2399,7 +2483,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "website": "https://observatorioconvivencia.com/",
-    "description": "El Observatorio para la Convivencia Escolar es un órgano colegiado que sirve de instrumento a la comunidad educativa y a la sociedad para conocer, analizar y evaluar la convivencia en los centros docentes. Está adscrito a la Consejería de Educación y Cultura, a través de la Dirección General de Ordenación Académica. La finalidad del Observatorio será la de contribuir a la mejora del desarrollo de la actividad escolar en los centros docentes mediante la evaluación y el diagnóstico de la convivencia escolar, el análisis de los conflictos y la propuesta de medidas para la prevención de la violencia."
+    "description": "El Observatorio para la Convivencia Escolar es un órgano colegiado que sirve de instrumento a la comunidad educativa y a la sociedad para conocer, analizar y evaluar la convivencia en los centros docentes. Está adscrito a la Consejería de Educación y Cultura, a través de la Dirección General de Ordenación Académica. La finalidad del Observatorio será la de contribuir a la mejora del desarrollo de la actividad escolar en los centros docentes mediante la evaluación y el diagnóstico de la convivencia escolar, el análisis de los conflictos y la propuesta de medidas para la prevención de la violencia.",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Regional de la Discapacidad",
@@ -2420,7 +2508,11 @@
     "parents": ["Consell de Mallorca"],
     "scope": "local",
     "type": "publico",
-    "website": "https://esports.conselldemallorca.es/observatori-esportiu-de-mallorca"
+    "website": "https://esports.conselldemallorca.es/observatori-esportiu-de-mallorca",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "docs": [
@@ -2432,7 +2524,11 @@
     "name": "Observatorio de la Calidad de los Servicios de la Comunidad Autónoma de la Región de Murcia",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-de-la-calidad-de-los-servicios#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-de-la-calidad-de-los-servicios#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de Igualdad",
@@ -2610,7 +2706,11 @@
     "parents": ["Dirección General de Salud Pública", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://observatoriosaudepublica.sergas.gal/es"
+    "website": "https://observatoriosaudepublica.sergas.gal/es",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "Para <q>informar sobre la evolución de los principales indicadores relativos a la sostenibilidad económica, social y medioambiental de la agricultura de regadío en España</q>.",
@@ -2639,7 +2739,11 @@
     "parents": ["Diputación de Alicante"],
     "scope": "provincial",
     "type": "publico",
-    "website": "http://dipalicante.gobiernoabierto.femp.es/es/municipios/municipios/inicio"
+    "website": "http://dipalicante.gobiernoabierto.femp.es/es/municipios/municipios/inicio",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "description": "El Observatorio Coruñés contra a LGTBIfobia es un servicio dedicado a la escucha, asesosamiento, registro y denuncia de los incidentes o delitos de odio con un componente LGTBIfobico.",
@@ -2976,7 +3080,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://oic.itccanarias.org/"
+    "website": "https://oic.itccanarias.org/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -2992,7 +3100,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/turismo/estadisticas_y_estudios/"
+    "website": "https://www.gobiernodecanarias.org/turismo/estadisticas_y_estudios/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3008,7 +3120,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www3.gobiernodecanarias.org/ceic/energia/oecan/"
+    "website": "https://www3.gobiernodecanarias.org/ceic/energia/oecan/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3016,7 +3132,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.obidic.es"
+    "website": "https://www.obidic.es",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatori agroalimentari, rural i ambiental",
@@ -3072,7 +3192,11 @@
     "parents": ["Instituto Galego da Vivenda e Solo", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.observatoriodosoloempresarial.gal"
+    "website": "https://www.observatoriodosoloempresarial.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "Para promover la participación de la sociedad en la mejora y desarrollo de la actividad comercial en Galicia.",
@@ -3081,7 +3205,11 @@
     "name": "Observatorio do Comercio de Galicia",
     "parents": ["Dirección Xeral de Comercio", "Xunta de Galicia"],
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "email": "observatoriodelaguaemasesa@emasesa.com",
@@ -3101,7 +3229,11 @@
     "parents": ["Xunta de Galicia", "Instituto Enerxético de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.inega.gal/es/inega/puntos-de-encuentro-energeticos/observatorios"
+    "website": "https://www.inega.gal/es/inega/puntos-de-encuentro-energeticos/observatorios",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio de Gestión de EUSKALIT es un servicio cuyo objetivo es identificar, analizar y recopilar la información destacada de todo el mundo sobre la gestión avanzada y hacérsela llegar de forma accesible a las organizaciones y otros grupos de interés de Euskadi, para así ampliar su conocimiento en este ámbito.",
@@ -3235,7 +3367,11 @@
     "name": "Observatorio Económico de Melilla",
     "parents": ["Consejería de Presidencia"],
     "scope": "melilla",
-    "website": "https://elfarodemelilla.es/echa-a-andar-el-observatorio-economico-de-melilla/"
+    "website": "https://elfarodemelilla.es/echa-a-andar-el-observatorio-economico-de-melilla/",
+    "coordinates": {
+      "lat": 35.2929115,
+      "lon": -2.9507202
+    }
   },
   {
     "description": "El Observatorio de precios agrarios muestra semanalmente la evolución del precio que percibe el productor (origen) y el que paga el consumidor (destino). También incorpora costes de producción de diferentes cultivos y especies ganaderas que se irán completando semana a semana.",
@@ -3256,7 +3392,11 @@
     "name": "Banda Ancha de Navarra",
     "scope": "navarra",
     "type": "publico",
-    "website": "https://bandaancha.navarra.es/es/inicio"
+    "website": "https://bandaancha.navarra.es/es/inicio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Facilita diversos estudios, directivas, información de y para operadores turísticos regionales",
@@ -3277,7 +3417,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://turismoprofesional.navarra.es/es/observatorio-turistico"
+    "website": "https://turismoprofesional.navarra.es/es/observatorio-turistico",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Órgano encargado de analizar y estudiar la situación de la población joven de la Comunidad Foral de Navarra. El trabajo que realizamos desde el observatorio joven permite analizar y evaluar la situación, demandas y necesidades de la juventud Navarra, para, de esta manera, poder diseñar, elaborar y evaluar diferentes iniciativas, políticas y estrategias destinadas a mejorar las condiciones de vida del colectivo joven.",
@@ -3340,7 +3484,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.nasuvinsa.es/es/servicios/lursarea/observatorio"
+    "website": "https://www.nasuvinsa.es/es/servicios/lursarea/observatorio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio CIBIM revisa periódicamente la publicación de licitaciones públicas en la Plataforma de Contratación del Sector Público y plataformas existentes en Comunidades Autónomas, para identificar la incorporación de requisitos BIM y llevar a cabo un análisis cuantitativo y cualitativo de licitaciones con BIM publicadas en España a lo largo de los últimos años, según distintas clasificaciones.",
@@ -3404,7 +3552,11 @@
     "scope": "provincial",
     "to_date": "sigue",
     "type": "publico",
-    "website": "https://www.puertoalicante.com/negocio/observatorio/"
+    "website": "https://www.puertoalicante.com/negocio/observatorio/",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "email": "observatorioinfancia.assda@juntadeandalucia.es",
@@ -3521,7 +3673,11 @@
     "name": "Observatori de l'economia local de Sabadell",
     "scope": "local",
     "type": "mixto",
-    "website": "https://www.vaporllonch.cat/observatori-economia-local"
+    "website": "https://www.vaporllonch.cat/observatori-economia-local",
+    "coordinates": {
+      "lat": 41.5421013,
+      "lon": 2.1138977
+    }
   },
   {
     "name": "Observatorio deTransformación Digital de Navarra - Nafarroako Eraldaketa Digitalaren Behatokia",
@@ -3637,7 +3793,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://observatorisocial.tarragona.cat/"
+    "website": "https://observatorisocial.tarragona.cat/",
+    "coordinates": {
+      "lat": 41.1172364,
+      "lon": 1.2546057
+    }
   },
   {
     "description": "Para aportar información útil al agricultor como apoyo en sus procesos de toma de decisiones.",
@@ -4066,7 +4226,11 @@
     "website": "https://www.navarra.es/es/web/centro-documentacion-social",
     "type": "publico",
     "is_active": "Sí",
-    "email": "info.derechossociales@navarra.es"
+    "email": "info.derechossociales@navarra.es",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Como Observatorio la visión es poder tener varios objetivos fijados a largo plazo como concienciar la LGTBIfobia en la existente actual y erradicar contra la LGTBIfobia.",
@@ -4137,7 +4301,11 @@
     ],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://contratacionresponsablecanarias.org"
+    "website": "https://contratacionresponsablecanarias.org",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatori de l'Administració Digital",
@@ -4216,7 +4384,11 @@
     ],
     "scope": "menorca",
     "type": "publico",
-    "website": "https://www.obsam.cat"
+    "website": "https://www.obsam.cat",
+    "coordinates": {
+      "lat": 39.9492572,
+      "lon": 4.0499642
+    }
   },
   {
     "name": "Observatorio de la gestión del agua en España",
@@ -4249,7 +4421,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://diversidad-funcional.ayto-fuenlabrada.es/observatorio-municipal-de-la-dependencia.php"
+    "website": "https://diversidad-funcional.ayto-fuenlabrada.es/observatorio-municipal-de-la-dependencia.php",
+    "coordinates": {
+      "lat": 40.282476,
+      "lon": -3.7923422
+    }
   },
   {
     "name": "Observatorio Turístico de Alcobendas",
@@ -4274,7 +4450,11 @@
         "name": "Sumérgete en el Turismo Cultural de Alcobendas: ¡Un Destino Inolvidable!"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.5400082,
+      "lon": -3.6358494
+    }
   },
   {
     "description": "El objetivo de este informe estadístico, de carácter anual, es conocer de una forma completa e integrada las pautas de la visita y el perfil del visitante, tanto turistas como excursionistas, entre otros aspectos. Es decir, se trata de determinar los perfiles del visitante que llega a la ciudad de Málaga: cuáles son sus motivaciones iniciales, cómo organizan su viaje, qué tipo de actividades realizan durante su estancia, cómo valoran la oferta disponible y el viaje en función de sus expectativas iniciales, entre otros aspectos relevantes.",
@@ -4329,7 +4509,11 @@
       "Colegio de Sociología y Politología de Navarra"
     ],
     "scope": "navarra",
-    "website": "https://gobiernoabierto.navarra.es/es/participacion/enviar-aportacion/1587/observatorio-participacion-ciudadana-navarra"
+    "website": "https://gobiernoabierto.navarra.es/es/participacion/enviar-aportacion/1587/observatorio-participacion-ciudadana-navarra",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Es un órgano colegiado y consultivo que dependiendo de la Dirección General competente en materia de lucha contra la brecha digital trata de ser un foro de participación que permita el impulso compartido entre las administraciones públicas, los agentes económicos y sociales y la sociedad civil organizada en la lucha contra la brecha digital. Servirá de plataforma para planificar, estudiar y analizar el entorno y la realidad socioeconómica valenciana en materia de brecha digital.",
@@ -4375,7 +4559,11 @@
     "parents": ["Servicios sociales, empleo y vivienda", "Gobierno de Navarra"],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.observatoriorealidadsocial.es"
+    "website": "https://www.observatoriorealidadsocial.es",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Es <q>una herramienta para centralizar la información sobre accesibilidad en el País Vasco y que esté a disposición de todas las personas interesadas</q>.",
@@ -4424,7 +4612,11 @@
     "from_date": "15/01/2012",
     "parents": [
       "Puede encontrarse el anuncio de su creación en [este artículo del BOE](https://www.boe.es/buscar/act.php?id=BOE-A-2012-4187)."
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.5941788,
+      "lon": -5.5704747
+    }
   },
   {
     "docs": [
@@ -4604,7 +4796,11 @@
         "name": "- Aforos y balances de cultivos (Anual)."
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Desca",
@@ -4954,7 +5150,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.astursalud.es/noticias/-/noticias/observatorio-sobre-drogas-y-adiccion-a-las-bebidas-alcoholicas-del-principado-de-asturias"
+    "website": "https://www.astursalud.es/noticias/-/noticias/observatorio-sobre-drogas-y-adiccion-a-las-bebidas-alcoholicas-del-principado-de-asturias",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "is_active": "Sí",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -6652,5 +6652,274 @@
     "type": "mixto",
     "is_active": "No",
     "from_date": "Anunciado"
+  },
+  {
+    "name": "Observatorio para el Impulso Demográfico",
+    "description": "Observatorio/atlas de indicadores y mapas sobre demografía y territorio en la provincia de Huesca. <a href=\"https://www.dphuesca.es/observatorio-impulso-demografico\">Sitio web</a>.",
+    "parents": ["Diputación Provincial de Huesca"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dphuesca.es/observatorio-impulso-demografico"
+  },
+  {
+    "name": "Observatorio Provincial de Sostenibilidad de Albacete (OPSA)",
+    "description": "Plataforma provincial de indicadores de sostenibilidad (OPSA). <a href=\"https://observatoriosostenibilidad.dipualba.es/\">Sitio web</a>.",
+    "parents": ["Diputación de Albacete"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://observatoriosostenibilidad.dipualba.es/"
+  },
+  {
+    "name": "Observatorio de la Agenda Rural Sostenible de la provincia de Segovia",
+    "description": "Web/observatorio para el seguimiento de la Agenda Rural Sostenible de la provincia (indicadores y plan de acción). <a href=\"https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia\">Anuncio y enlace</a>.",
+    "parents": ["Diputación de Segovia"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia"
+  },
+  {
+    "name": "Observatori de la Qualitat de l'Aire del Camp de Tarragona (OQACT)",
+    "description": "Iniciativa/observatorio de calidad del aire en el Camp de Tarragona, con enfoque colaborativo y participación público-privada. <a href=\"https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/\">Fuente</a>.",
+    "parents": ["Institut Cerdà", "Repsol", "AEQT"],
+    "scope": "cataluna",
+    "type": "mixto",
+    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/"
+  },
+  {
+    "name": "OTIGRAN (Observatorio Turístico de Gran Canaria)",
+    "description": "Observatorio de innovación en turismo sostenible de Gran Canaria, con informes e indicadores para la toma de decisiones. <a href=\"https://observatorioturisticograncanaria.com/\">Sitio web</a>.",
+    "parents": ["Cabildo de Gran Canaria", "Turismo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://observatorioturisticograncanaria.com/"
+  },
+  {
+    "name": "Euskal Herriko Giza Eskubideen Behatokia (GEBEHATOKIA)",
+    "description": "Behatokia de derechos humanos (GEBEHATOKIA) publicado en el portal oficial del Gobierno Vasco. <a href=\"https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/\">Ficha</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/"
+  },
+  {
+    "name": "Jokoaren Euskal Behatokia",
+    "description": "Observatorio vasco del juego/apuestas. <a href=\"https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/"
+  },
+  {
+    "name": "Turismoaren Euskal Behatokia",
+    "description": "Observatorio vasco de turismo. <a href=\"https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/"
+  },
+  {
+    "name": "Banda Zabal Ultralasterraren Euskal Behatokia",
+    "description": "Observatorio vasco de banda ancha ultrarrápida. <a href=\"https://www.euskadibandazabala.eus/index.php?idm=eu\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu"
+  },
+  {
+    "name": "Euskal Ekintzailetzaren Behatokia (Observatorio Vasco del Emprendimiento)",
+    "description": "Observatorio Vasco del Emprendimiento (Euskal Ekintzailetzaren Behatokia). <a href=\"https://eeb-ove.eus/observatorio/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco", "Universidad del País Vasco (UPV/EHU)"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://eeb-ove.eus/observatorio/"
+  },
+  {
+    "name": "Behatokia (Gizarte Aurreikuspen Osagarria)",
+    "description": "Behatokia sobre previsión social complementaria (Gizarte Aurreikuspen Osagarria). <a href=\"https://www.euskadi.eus/zer-da/web01-a2opsc/eu/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/"
+  },
+  {
+    "name": "Observatorio de la calidad del aire (Terrassa)",
+    "description": "Observatorio municipal vinculado al seguimiento del plan de mejora de la calidad del aire. <a href=\"https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire\">Sitio web</a>.",
+    "parents": ["Ajuntament de Terrassa"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Terrassa (Barcelona)",
+    "website": "https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire"
+  },
+  {
+    "name": "Observatori de l'aigua (Terrassa)",
+    "description": "Mención al \"Observatori de l'aigua\" municipal en materiales/recursos educativos del Ayuntamiento. <a href=\"https://www.terrassa.cat/recursos-educatius\">Referencia</a>.",
+    "parents": ["Ajuntament de Terrassa"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Terrassa (Barcelona)",
+    "website": "https://www.terrassa.cat/recursos-educatius"
+  },
+  {
+    "name": "Observatori ambiental Litoral-Besòs",
+    "description": "Referencia municipal a un observatorio ambiental Litoral-Besòs como recurso externo sobre calidad del aire. <a href=\"https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire\">Enlace</a>.",
+    "scope": "cataluna",
+    "type": "publico",
+    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire"
+  },
+  {
+    "name": "Observatorio Valenciano de Salud",
+    "description": "Portal de indicadores de salud pública de la Generalitat Valenciana. <a href=\"https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud\">Sitio web</a>.",
+    "parents": ["Generalitat Valenciana"],
+    "scope": "comunidad_valenciana",
+    "type": "publico",
+    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud"
+  },
+  {
+    "name": "Euskadiko Osasun Behatokia",
+    "description": "Observatorio de salud del País Vasco (Osasun behatokia). <a href=\"https://www.euskadi.eus/euskadiko-osasun-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/"
+  },
+  {
+    "name": "Observatorio Gallego de Salud Pública",
+    "description": "Observatorio de salud pública de Galicia (referencia en noticia sobre su lanzamiento). <a href=\"https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/\">Fuente</a>.",
+    "parents": ["Xunta de Galicia", "Consellería de Sanidade", "SERGAS"],
+    "scope": "galicia",
+    "type": "publico",
+    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/"
+  },
+  {
+    "name": "Observatorio Metropolitano de Transporte de Granada",
+    "description": "Anunciado en septiembre de 2025 como observatorio metropolitano de transporte/movilidad sostenible. <a href=\"https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html\">Fuente</a>.",
+    "scope": "andalucia",
+    "type": "publico",
+    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html"
+  },
+  {
+    "name": "Observatorio de la Movilidad Metropolitana del CTAZ-USJ",
+    "description": "Observatorio/cuadro de mandos asociado al Consorcio de Transportes del Área de Zaragoza (CTAZ) y la Universidad San Jorge (USJ). <a href=\"https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/\">Acceso</a>.",
+    "parents": [
+      "Consorcio de Transportes del Área de Zaragoza (CTAZ)",
+      "Universidad San Jorge (USJ)"
+    ],
+    "scope": "aragon",
+    "type": "mixto",
+    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/"
+  },
+  {
+    "name": "Observatorio para la Accesibilidad de Gran Canaria",
+    "description": "Observatorio para el seguimiento/impulso de la accesibilidad en Gran Canaria. <a href=\"https://www.grancanariaaccesible.info/observatorio/\">Sitio web</a>.",
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://www.grancanariaaccesible.info/observatorio/"
+  },
+  {
+    "name": "Observatorio del Comercio de Gran Canaria",
+    "description": "Observatorio/barómetro del comercio en Gran Canaria. <a href=\"https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/\">Sitio web</a>.",
+    "parents": ["Cámara de Comercio de Gran Canaria"],
+    "scope": "canarias",
+    "type": "mixto",
+    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/"
+  },
+  {
+    "name": "Observatorio de Prospectiva para la Gobernanza Insular",
+    "description": "Referencia a un observatorio de prospectiva para la gobernanza insular en documentación de seguimiento/evaluación del Cabildo. <a href=\"https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion\">Fuente</a>.",
+    "parents": ["Cabildo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion"
+  },
+  {
+    "name": "Observatorio de aves (Dunas de Maspalomas)",
+    "description": "Observatorio de aves en el ámbito de las Dunas de Maspalomas (espacio/instalación de observación). <a href=\"https://cabildo.grancanaria.com/dunas/observatorio-de-aves\">Sitio web</a>.",
+    "parents": ["Cabildo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves"
+  },
+  {
+    "name": "Fundación Canaria Observatorio de Temisas",
+    "description": "Referencia a la Fundación Canaria Observatorio de Temisas en noticia de subvención del Cabildo (planetario). <a href=\"https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26\">Fuente</a>.",
+    "parents": [
+      "Fundación Canaria Observatorio de Temisas",
+      "Cabildo de Gran Canaria"
+    ],
+    "scope": "canarias",
+    "type": "mixto",
+    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26"
+  },
+  {
+    "name": "Observatorio de Datos Abiertos (Diputación de Castellón)",
+    "description": "Acción/entregable de Diputación de Castellón para la puesta en marcha de un Observatorio de Datos Abiertos. <a href=\"https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59\">Fuente</a>.",
+    "parents": ["Diputación de Castellón"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59"
+  },
+  {
+    "name": "Observatorio Urbano de la Agenda Urbana de Valverde de Burguillos",
+    "description": "Observatorio urbano asociado a la Agenda Urbana local para seguimiento/indicadores. <a href=\"https://agendaurbanavalverdeburguillos2030.badajoz.es/\">Sitio web</a>.",
+    "parents": ["Ayuntamiento de Valverde de Burguillos"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Valverde de Burguillos (Badajoz)",
+    "website": "https://agendaurbanavalverdeburguillos2030.badajoz.es/"
+  },
+  {
+    "name": "Observatorio ornitológico en Maderuelo",
+    "description": "Referencia a un observatorio ornitológico en el marco de actuaciones/planes provinciales. <a href=\"https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica\">Fuente</a>.",
+    "parents": ["Diputación de Segovia"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica"
+  },
+  {
+    "name": "Observatorio Local de Sostenibilidad de Albacete (OLSA)",
+    "description": "Referencia al Observatorio Local de Sostenibilidad de Albacete (OLSA) en información del OPSA. <a href=\"https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj\">Fuente</a>.",
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Albacete",
+    "website": "https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj"
+  },
+  {
+    "name": "Observatorio económico de la provincia de Sevilla",
+    "description": "Panel de indicadores económicos, desarrollado por el Colegio Profesional de Economistas de Sevilla con la colaboración/financiación de la Diputación de Sevilla y Prodetur. <a href=\"https://www.observatorioeconomicosevilla.com/\">Sitio web</a>.",
+    "parents": [
+      "Colegio Profesional de Economistas de Sevilla",
+      "Diputación de Sevilla",
+      "Prodetur"
+    ],
+    "scope": "provincial",
+    "type": "mixto",
+    "website": "https://www.observatorioeconomicosevilla.com/"
+  },
+  {
+    "name": "Indicadores de Administración Digital (Ayuntamiento de Madrid)",
+    "description": "Página municipal de indicadores de administración digital, presentada como instrumento de observación/seguimiento. <a href=\"https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Madrid"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Madrid",
+    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default"
+  },
+  {
+    "name": "Observatorio del Ruido (Algete)",
+    "description": "Referencia periodística a la reactivación del Observatorio del Ruido municipal. <a href=\"https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Algete"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Algete (Madrid)",
+    "website": "https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624"
+  },
+  {
+    "name": "Observatorio de la Calidad del Aire (Algete)",
+    "description": "Referencia municipal a datos de un \"Observatorio de la Calidad del Aire\" en Algete. <a href=\"https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Algete"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Algete (Madrid)",
+    "website": "https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item"
   }
 ]

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -202,7 +202,11 @@
   },
   {
     "name": "Observatorio da Violencia no Contorno Laboral",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio Territorial de Estudios y Análisis (OTEA) de Granada es una entidad esencial para el desarrollo y la planificación estratégica de la provincia. Su función es apoyar a las entidades locales en la promoción económica y el desarrollo sostenible, proporcionando estudios técnicos y asistencia en la modernización de servicios públicos. Además, OTEA juega un papel crucial en el seguimiento de la evolución del empleo y los sectores productivos, así como en la difusión de buenas prácticas que pueden ser aplicadas en diferentes contextos, fortaleciendo así la gestión territorial y la economía circular.\n\n- Diputación de Granada",
@@ -346,7 +350,11 @@
   },
   {
     "name": "Observatorio de la Infancia de Andalucía",
-    "scope": "andalucia"
+    "scope": "andalucia",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Tiene como principal cometido el análisis del mercado laboral en nuestro municipio, tanto en lo referente a los/as demandantes de empleo, como sobre las contrataciones realizadas en las empresas del municipio.\n\nLos objetivos del Observatorio Local de Empleo de Fuenlabrada son:\n\nProfundizar en el conocimiento del mercado de trabajo de Fuenlabrada, identificando las necesidades de las empresas.\n\nConocer las características del perfil general de las personas desempleadas: sexo, edad, niveles formativos, población más afectada, tiempo de permanencia en el desempleo, grupos profesionales, etc.\n\nConocer las características de las contrataciones realizadas en Fuenlabrada: nº contratos, características, ubicación por sectores de actividad, características de las personas contratadas, etc… También de las afiliaciones a la seguridad social\n\nDifundir los principales resultados y estadísticas, a través de Informes y Estudios:\n\nAyuntamiento de Fuenlabrada",
@@ -370,7 +378,11 @@
   },
   {
     "name": "Observatorio de la Infancia de Cataluña / Observatori dels Drets dels Infants",
-    "scope": "cataluna"
+    "scope": "cataluna",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de Asturias",
@@ -426,15 +438,27 @@
   },
   {
     "name": "Observatorio de Infancia del País Vasco",
-    "scope": "pais_vasco"
+    "scope": "pais_vasco",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de Infancia de Cantabria",
-    "scope": "cantabria"
+    "scope": "cantabria",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de les Illes Balears",
-    "scope": "islas_baleares"
+    "scope": "islas_baleares",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Para <q>analizar permanentemente la situación del libro, la lectura y las bibliotecas en su conjunto, tal y como se establece en la disposición adicional segunda de la Ley 10/2007, de 22 de junio, de la Lectura, el Libro y las Bibliotecas</q>.",
@@ -727,7 +751,11 @@
     "parents": ["Junta de Andalucía", "Consejería de Salud y Consumo"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.osman.es"
+    "website": "https://www.osman.es",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio do xogo",
@@ -917,7 +945,11 @@
     "parents": ["Diputación Provincial de Cáceres"],
     "scope": "provincial",
     "type": "publico",
-    "website": "http://observatorio.dip-caceres.es/"
+    "website": "http://observatorio.dip-caceres.es/",
+    "coordinates": {
+      "lat": 39.4745175,
+      "lon": -6.3716761
+    }
   },
   {
     "name": "Observatorio de la Comunidad de Castilla y León. Sección de Género",
@@ -972,31 +1004,55 @@
     "name": "Observatorio TransfomAcción y ParticipAcción",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.observatoriotransformacion.com"
+    "website": "https://www.observatoriotransformacion.com",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Regional de la Sociedad de la Información de Castilla y León (ORSI)",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.aytoburgos.es/-/observatorio-regional-de-la-sociedad-de-la-informacion-de-castilla-y-leon-orsi-"
+    "website": "https://www.aytoburgos.es/-/observatorio-regional-de-la-sociedad-de-la-informacion-de-castilla-y-leon-orsi-",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio de Agresiones",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.saludcastillayleon.es/profesionales/es/prevencion-riesgos-laborales/plan-integral-frente-agresiones/observatorio-agresiones"
+    "website": "https://www.saludcastillayleon.es/profesionales/es/prevencion-riesgos-laborales/plan-integral-frente-agresiones/observatorio-agresiones",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Galego Contra a Discriminación por Orientación Sexual e Identidade de Xénero",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Biodiversidade",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Violencia de Xénero",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "1. conocer, la situación del precio del mercado de alquiler libre en la ciudad.\n\nAyuntamiento de Alicante\n\nLa tarea la hace una consultora externa ( Factoría, Gestión y Consultoría, s.l.)",
@@ -1016,7 +1072,11 @@
   },
   {
     "name": "Observatorio Galego de Acción Voluntaria",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio de Datos Culturales de Barcelona es una iniciativa del Instituto de Cultura del Ayuntamiento de Barcelona que nació en 2015. La misión de este observatorio es elaborar y difundir datos, indicadores e informes sobre la realidad cultural de la ciudad, y poner toda la información al alcance de instituciones, agentes culturales, comunidad científica y público interesado de una manera ordenada y accesible, con el objetivo de ampliar y mejorar el conocimiento que tenemos sobre la vida cultural barcelonesa.",
@@ -1050,7 +1110,11 @@
   },
   {
     "name": "Observatorio Galego de Convivencia Escolar",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Startup de la Comunidad Valenciana",
@@ -1085,11 +1149,19 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Ofrece formulario de contacto.",
-    "from_date": "2016"
+    "from_date": "2016",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego de Educación Ambiental",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "is_active": "No",
@@ -1148,7 +1220,11 @@
     ],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/observatorio-vasco-cultura/"
+    "website": "https://www.euskadi.eus/observatorio-vasco-cultura/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "El Observatorio de I+d+I tiene como objetivo aunar toda la información de la actividad investigadora y de la innovación que se realiza en la universidad para que sea pública y accesible para la comunidad universitaria, el tejido empresarial y en general para cualquier usuario interesado en la producción científica que se realiza en la UPM y en los resultados generados.",
@@ -1335,7 +1411,11 @@
   },
   {
     "name": "Observatorio Territorial de Andalucía",
-    "scope": "andalucia"
+    "scope": "andalucia",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio para la Cibersociedad"
@@ -1368,11 +1448,19 @@
   },
   {
     "name": "Observatorio da Mobilidade de Terras de Galicia",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Xuventude",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio de costes de transportes de mercancías por carretera de Galicia",
@@ -1397,7 +1485,11 @@
     "parents": ["Consellería competente en materia de familia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.xunta.gal/dog/Publicados/2019/20190429/AnuncioG0425-150419-0001_gl.html"
+    "website": "https://www.xunta.gal/dog/Publicados/2019/20190429/AnuncioG0425-150419-0001_gl.html",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "a) Efectuar análisis y propuestas de actuación sobre el ejercicio de los derechos fundamentales y libertades públicas por los miembros de las Fuerzas Armadas.\r\nb) Elaborar, de oficio o a petición de parte, informes y estudios sobre el régimen de personal y las condiciones de vida en las Fuerzas Armadas.\r\nc) Proponer medidas que ayuden a la conciliación de la vida profesional, personal y familiar de los militares.\r\nd) Promover la adaptación del régimen del personal militar a los cambios que se operen en la sociedad y en la función pública.\r\ne) Analizar los problemas que en el entorno familiar de los afectados se producen como consecuencia de su disponibilidad, movilidad geográfica y de su específico ejercicio profesional que conlleva la participación en operaciones en el exterior.\r\nf) Evaluar la aportación adicional de recursos humanos a las Fuerzas Armadas a través de las diferentes modalidades de reservistas.\r\ng) Velar por la aplicación a los militares retirados de la normativa que ampara sus derechos pasivos y asistenciales y, en su caso, efectuar propuestas de mejora sobre ésta.\n\nSe compone de nueve personalidades de reconocido prestigio en el ámbito de la Defensa, recursos humanos o en derechos fundamentales y libertades públicas, elegidos cinco por el Congreso y cuatro por el Senado para un mandato de cinco años.",
@@ -1557,7 +1649,11 @@
         "name": "Memoria Anual del Observatorio del Mercado de Trabajo 2023",
         "url": "https://inaem.aragon.es/documents/51284/2219399/MEMORIA+OBSERVATORIO+2023.pdf/f21a07bc-6ee5-de35-3ad0-7ea943f00089?version=1.0&t=1711103605824&download=true"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "Si",
@@ -1668,7 +1764,11 @@
         "name": "Decreto de creación (referencia normativa citada en OBECAN)",
         "url": "http://www.gobiernodecanarias.org/boc/1998/160/003.html"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio Socioeconómico de la Provincia de Badajoz",
@@ -1830,7 +1930,11 @@
         "name": "Observatorio de la Cultura (AGCEX)",
         "url": "https://www.agcex.org/observatorio-de-la-cultura/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatori Ciutadà de la Biodiversitat",
@@ -1927,7 +2031,11 @@
         "name": "[1.La eInclusió a les Illes Balears, (2014).](https://www.fundaciobit.org/wp-content/uploads/2020/03/Informe-eInclusio-2014.pdf)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "La Xarxa d’Observatoris del Desenvolupament Econòmic Local (XODEL) és un espai on es\r\ngenera, es comparteix i es difon informació i on es fomenta el debat, la reflexió i l’intercanvi\r\nd’experiències entre els observatoris membres.\n\nLa Xarxa està composta de 21 observatoris i coordinada per l’Oficina Tècnica d’Estratègies per al\r\nDesenvolupament Econòmic de l’Àrea de Desenvolupament Econòmic i Turisme de la Diputació\r\nde Barcelona.\n\nLa Xarxa disposa d’una comunitat virtual (https://xodel.diba.cat), una eina de comunicació\r\nhoritzontal que permet al grup comunicar-se, treballar de manera col·laborativa i gestionar\r\nconeixement distribuït mitjançant diverses eines de participació.\n\nLa Xarxa està composta de 21 observatoris i coordinada per l’Oficina Tècnica d’Estratègies per al\r\nDesenvolupament Econòmic de l’Àrea de Desenvolupament Econòmic i Turisme de la Diputació\r\nde Barcelona\n\n**Observatoris**\n\n**_Observatoris municipals_**\n\n[Observatori de desenvolupament local de Badalona](http://www.badalona.cat/)\n\n[Observatori econòmic i social de Barberà del Vallès](https://www.bdv.cat/observatori-economic-i-social)\n\n[Departament d’estudis de la Gerència de política econòmica i desenvolupament local (Barcelona)](https://ajuntament.barcelona.cat/economiatreball/ca/documents)\n\n[Observatori socioeconòmic de l'Hospitalet de Llobregat](http://www.dinamitzaciolocallh.cat/)\n\n[Servei d’estratègia i governança (Mataró)](https://www.mataro.cat/ca/la-ciutat/observatori-de-ciutat)\n\n[Gabinet d’estudis i estadístiques (Rubí)](https://www.rubi.cat/ca/ajuntament/transparencia/observatoridelaciutat/gabinet-destudis-i-estadistiques)\n\n[Observatori de l’economia local (Sabadell)](http://www.vaporllonch.cat/observatori-economia-local)\n\n[Observatori socioeconòmic de Grameimpuls (Santa Coloma de Gramenet)](https://www.grameimpuls.cat/observatori/)\n\n[Servei d’estudis i Observatori de la ciutat (Terrassa) ](http://www.terrassa.cat/servei-estudis)\n\n**_Observatoris supramunicipals_**\n\n[Observatori del desenvolupament local de l'Alt Penedès i del Garraf](https://mancomunitat.cat/temes/banc-de-dades-socioeconomiques/)\n\n[Observatori socioeconòmic de l’Anoia](http://www.observatorianoia.cat/)\n\n[Observatori del Bages](https://www.manresa.cat/web/article/1006-informacio-socioeconomica)\n\n[Observatori comarcal del Baix Llobregat](http://www.elbaixllobregat.cat/observatori)\n\n[Observatori de desenvolupament local del Berguedà](http://www.adbergueda.cat/territori)\n\n[Observatori de desenvolupament local del Maresme](http://www.ccmaresme.cat/observatori)\n\n[Observatori Metropolità](https://agenciaeconomica.amb.cat/)\n\n[Observatori estratègic del Moianès](http://www.ccmoianes.cat/observatori/que-es-lobservatori-estrategic-del-moianes/)\n\n[Observatori socioeconòmic d’Osona](http://www.observatorisocioeconomicosona.cat/)\n\n[Observatori de la Riera de Caldes](http://www.rieradecaldes.com/observatori.html)\n\n[Observatori comarcal del Vallès Occidental](https://www.consellvallesoccidental.cat/observatori/)\n\n[L’Observatori – Centre d’estudis del Vallès Oriental](https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/)",
@@ -1960,7 +2068,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://xodel.diba.cat"
+    "website": "https://xodel.diba.cat",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "El Observatorio es el grupo de trabajo de la Comunidad de Madrid para la evaluación, el seguimiento y la propuesta de las acciones a realizar en el marco del Plan de Capacitación Digital para los Ciudadanos de la Comunidad de Madrid 2022-2025.\n\nCompetencias\r\na) Definir y perfeccionar el sistema de indicadores del Plan, elaborando planes de seguimiento trimestrales que permitan evaluar el desarrollo, resultado e impacto del plan.\r\nb) Difundir en la sociedad los contenidos y objetivos del Plan de Capacitación Digital para los Ciudadanos de la Comunidad de Madrid 2022-2025, y recoger las propuestas e iniciativas sociales que surjan en su desarrollo.\r\nc) Detectar cualquier desviación operativa y trasladar la información al grupo operativo para permitir la toma de decisiones basadas en las evidencias encontradas en los distintos informes de seguimiento.\r\nd) Fomentar la cooperación y colaboración en las actuaciones de las distintas consejerías en materia de desarrollo de competencias digitales para evitar solapamientos y duplicidades, proponiendo una solución a las consejerías implicadas en caso de que se produjeran intersecciones entre los colectivos en riesgo de exclusión social, sin perjuicio de las competencias atribuidas a cada una de ellas.\r\ne) Identificar nuevas propuestas y casos de éxito que puedan ser replicados en el ámbito del Plan.",
@@ -2217,7 +2329,11 @@
     "name": "Observatorio de Comercio del Gobierno Vasco",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "El OMAU desarrolla tres campos de trabajo. (1) Por una parte, realiza el seguimiento de indicadores medioambientales tanto de la ciudad de Málaga, como de las ciudades socias. En el caso de la Ciudad de Málaga los indicadores de seguimiento están directamente relacionados con la puesta en práctica en 2006 de la Agenda 21. Para el conjunto de los socios se emplea el Sistema Integrado de Indicadores Urbanos realizados junto a UN-HABITAT de Naciones Unidas, con un conjunto inicial de 37 indicadores.\n\nLos indicadores de seguimiento son un instrumento muy útil para confrontar situaciones ambientales urbanas en diferentes periodos de tiempo, para conocer y saber si avanzamos hacía los objetivos propuestos o tenemos problemas para alcanzar las metas establecidas en la Agenda 21. En algunos de los indicadores empleamos el soporte GIS para realizar el seguimiento periódico.\n\n(2) El OMAU es también un centro de intercambio de experiencias donde, de forma regular, se celebran conferencias o mesas redondas sobre temas de actualidad en el campo del Medio Ambiente Urbano. En 2004 y 2005 se celebraron los primeros cursos de formación, tanto presencial, como on line, que deben tener su continuidad anual, incorporando propuestas de trabajo o formatos novedosos que se realicen en otros ámbitos.\n\n(3) El Centro de Documentación del Programa URB-AL (CDPU) asienta su sede en el Observatorio, reforzando la biblioteca convencional y virtual que el OMAU dispone. El CDPU supone la concentración de toda la información desarrollada por el Programa URB-AL desde 1995, periodo en el que se desarrollaron 13 redes de ciudades que agruparon a 2.500 ciudades europeas y americanas. El CDPU ha recuperado los 192 proyectos URB-AL aprobados por la Comisión Europea, y que se desarrollaron entre 1998 y previsiblemente 2009. La Web del CDPU posibilita encontrar la documentación de los diferentes proyectos tanto a través de un buscador temático, como a través de su relación original con una determinada Red, funcionando a modo de biblioteca virtual de Buenas Practicas Urbanas.\n\nEn un principio es gestionado por dos funcionarios municipales, uno de ellos responsable del observatorio. Contrató 14 falsos autónomos cuyo despido fue anulado por el Tribunal Superior de Justicia y tuvieron que ser readmitidos.",
@@ -2242,7 +2358,11 @@
     "scope": "pais_vasco",
     "twitter": "@eeb_ove",
     "type": "publico",
-    "website": "https://eeb-ove.eus/inicio/"
+    "website": "https://eeb-ove.eus/inicio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "from_date": "30 abril 2024",
@@ -2257,34 +2377,54 @@
     "name": "Observatorio Vasco de Vivienda",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/observatoriovivienda/"
+    "website": "https://www.euskadi.eus/observatoriovivienda/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco del Juego",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-vasco-juego/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-vasco-juego/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de Periodismo Machista",
     "scope": "pais_vasco",
     "twitter": "@pemachista",
     "type": "publico",
-    "website": "https://periodismomachista.com/"
+    "website": "https://periodismomachista.com/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco sobre Acoso y Discriminación",
     "scope": "pais_vasco",
     "twitter": "@ObservVascoAcos",
     "type": "publico",
-    "website": "https://www.observatoriovascosobreacoso.com/"
+    "website": "https://www.observatoriovascosobreacoso.com/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de la Juventud",
     "scope": "pais_vasco",
     "twitter": "@gaztebehatokia",
     "type": "publico",
-    "website": "https://www.gazteaukera.euskadi.eus/hasiera/"
+    "website": "https://www.gazteaukera.euskadi.eus/hasiera/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "OBITen",
@@ -2341,7 +2481,11 @@
     "name": "Observatorio de Coyuntura Industrial",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.irekia.euskadi.eus/es/tags/observatoriodecoyunturaindustrial?uid=5196"
+    "website": "https://www.irekia.euskadi.eus/es/tags/observatoriodecoyunturaindustrial?uid=5196",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de Inmigración (Ikuspegi)",
@@ -2467,7 +2611,11 @@
     "scope": "pais_vasco",
     "twitter": "@BehatokiaLGTBI",
     "type": "publico",
-    "website": "https://lgtbi-behatokia.eus/"
+    "website": "https://lgtbi-behatokia.eus/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "docs": [
@@ -2558,7 +2706,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "website": "https://www.carm.es/web/pagina?IDCONTENIDO=5137&IDTIPO=11&RASTRO=c374$m5828",
-    "description": "La presente Orden tiene por objeto la creación del Observatorio Regional de la Discapacidad, cuya finalidad será la obtención y mantenimiento de la información necesaria para el conocimiento de las necesidades de las personas con discapacidad y el impacto de las actuaciones de los Sistemas de Protección Social sobre este colectivo. Asimismo, con este instrumento se pretende analizar y valorar la evolución de la discapacidad en la Región de Murcia, así como conocer los aspectos que se consideren importantes dentro de los citados Sistemas y la mejora de la calidad de vida de este colectivo"
+    "description": "La presente Orden tiene por objeto la creación del Observatorio Regional de la Discapacidad, cuya finalidad será la obtención y mantenimiento de la información necesaria para el conocimiento de las necesidades de las personas con discapacidad y el impacto de las actuaciones de los Sistemas de Protección Social sobre este colectivo. Asimismo, con este instrumento se pretende analizar y valorar la evolución de la discapacidad en la Región de Murcia, así como conocer los aspectos que se consideren importantes dentro de los citados Sistemas y la mejora de la calidad de vida de este colectivo",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "description": "El Observatorio Deportivo de Mallorca tiene el objetivo de fomentar una práctica deportiva responsable, unos hábitos saludables y la formación en torno a diferentes temas de actualidad deportiva.\n\nPlan de asesoramiento: formación y orientación dirigida a clubs, asociaciones de madres y padres de alumnos, federaciones deportivas, entrenadores...\r\nEls valors de l’esport: charlas impartidas por deportistas de alto nivel, que profundizan en los valores que aporta el ejercicio físico al desarrollo personal.",
@@ -2598,13 +2750,21 @@
     "name": "Observatorio de Igualdad",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-de-igualdad#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-de-igualdad#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Regional contra la Discriminación por Orientación Sexual e Identidad de Género",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Permanente Andaluz de las Migraciones (OPAM)",
@@ -2693,7 +2853,11 @@
     "parents": ["Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://agricultura.gencat.cat/ca/departament/estadistiques/observatori-agroalimentari-preus/"
+    "website": "https://agricultura.gencat.cat/ca/departament/estadistiques/observatori-agroalimentari-preus/",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Es <q>un instrumento de análisis y de actuación que, en el ámbito de la Administración de la Justicia, promueve iniciativas y medidas dirigidas a erradicar el problema social de la violencia doméstica y de género</q>.",
@@ -2888,7 +3052,11 @@
     "name": "Observatorio Ocupacional de la Universidad Miguel Hernández",
     "parents": ["Universidad Miguel Hernández"],
     "scope": "comunidad_valenciana",
-    "website": "https://observatorio.umh.es/"
+    "website": "https://observatorio.umh.es/",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Para <q>Constituir un instrumento de transparencia orientado a la investigación de la tributación local, la financiación a través de transferencias de otras administraciones, y en general, cualquier información de naturaleza económica con incidencia en el ámbito de la Administración Municipal</q>.",
@@ -2955,7 +3123,11 @@
     "parents": ["Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "http://www.observatoriobiomasa.gal"
+    "website": "http://www.observatoriobiomasa.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio de Precios de Canarias",
@@ -3052,7 +3224,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.culturanavarra.es/es/presentacion-8"
+    "website": "https://www.culturanavarra.es/es/presentacion-8",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "h) Publicar y difundir estudios, materiales y experiencias de educación para la convivencia y cultura de paz. i) Elaborar un informe anual sobre el estado de la convivencia y la conflictividad en los centros educativos, para lo que requerirá el apoyo informativo, documental y técnico de otras Administraciones Públicas con competencia en la materia y de los propios órganos y entidades de la Consejería competente en materia de educación, así como de entidades e instituciones privadas. j) Cualquier otra función de apoyo y asesoramiento vinculada a la recogida, análisis, difusión de la información y la investigación y la promoción de actuaciones en todas las materias relacionadas con la mejora de la convivencia en el ámbito de los centros educativos.",
@@ -3200,7 +3376,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.octsi.es/"
+    "website": "https://www.octsi.es/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3361,7 +3541,11 @@
     "parents": ["EUSKALIT, Fundación Vasca para la Excelencia"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskalit.net/observatorio/es/"
+    "website": "https://www.euskalit.net/observatorio/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "L'Observatori del Programa Ajuntament+Sostenible fa anualment un seguiment per valorar com evoluciona la consecució de les dues directrius estratègiques del programa:\n\n[Seguiment de la contractació](http://www.ajsosteniblebcn.cat/ca/seguiment-de-la-contractacio_99538): s'elabora un Informe de seguiment de les instruccions tècniques per a l’aplicació de criteris de sostenibilitat de l'Ajuntament de Barcelona que recull els indicadors de seguiment dels diferents grups de productes i serveis, els principals plecs ambientalitzats cada any, així com els principals reptes i objectius de futur.\n\n[Seguiment de l'ambientalització interna](http://www.ajsosteniblebcn.cat/ca/seguiment-de-l-ambientalitzacio-interna_99544): s'elabora un Informe de seguiment de l'ambientalització interna de l'Ajuntament de Barcelona que recull com s'han impulsat els compromisos prioritaris per avançar envers la sostenibilitat interna recollits en set àmbits de treball, així com un recull de les bones pràctiques que han dut a terme gerències i organismes municipals de forma descentralitzada.",
@@ -7467,7 +7651,11 @@
     "parents": ["Diputación Provincial de Huesca"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dphuesca.es/observatorio-impulso-demografico"
+    "website": "https://www.dphuesca.es/observatorio-impulso-demografico",
+    "coordinates": {
+      "lat": 42.1360615,
+      "lon": -0.0298027
+    }
   },
   {
     "name": "Observatorio Provincial de Sostenibilidad de Albacete (OPSA)",
@@ -7669,7 +7857,11 @@
     "parents": ["Cabildo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion"
+    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de aves (Dunas de Maspalomas)",
@@ -7677,7 +7869,11 @@
     "parents": ["Cabildo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves"
+    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Fundación Canaria Observatorio de Temisas",
@@ -7688,7 +7884,11 @@
     ],
     "scope": "canarias",
     "type": "mixto",
-    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26"
+    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de Datos Abiertos (Diputación de Castellón)",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -3594,7 +3594,11 @@
       "Xunta de Galicia', 'Vicepresidencia Primera', 'Consellería de Economía, Empleo e Innovación', 'Consorcio Aeronáutico Gallego"
     ],
     "scope": "galicia",
-    "website": "https://www.consorcioaeronautico.com/observatorio-aeroespacial/gl/"
+    "website": "https://www.consorcioaeronautico.com/observatorio-aeroespacial/gl/",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio tendrá como finalidad asesorar al Gobierno, formular planes de acción y programar actividades de conocimiento, intercambio y programación. Atendiendo a su finalidad, servirá de foro de diálogo permanente entre las distintas administraciones públicas y otras organizaciones representativas de intereses en el ámbito de la lusofonía, a fin de asegurar su participación activa en el abordaje de las relaciones de Galicia en dicho ámbito, así como aglutinará esfuerzos, coordinará las actuaciones público-privadas y procurará la consolidación en el tiempo de Galicia en el mundo de la lusofonía.",
@@ -3616,7 +3620,11 @@
       "Xunta de Galicia"
     ],
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "email": "ocj.dretssocials@gencat.cat",
@@ -3629,7 +3637,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/joventut/observatori_catala_de_la_joventut/index.html"
+    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/joventut/observatori_catala_de_la_joventut/index.html",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "docs": [
@@ -3643,7 +3655,11 @@
     "name": "Observatori Català de l’Esport",
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://inefc.gencat.cat/ca/inefc/projectes_institucionals/observatori-de-lesport/index.html"
+    "website": "https://inefc.gencat.cat/ca/inefc/projectes_institucionals/observatori-de-lesport/index.html",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "El Observatorio del pluralismo religioso en España aporta datos y diagnósticos sobre la diversidad de creencias y las necesidades vinculadas al ejercicio efectivo de la libertad religiosa para contribuir a la mejora de la gestión pública.",
@@ -3690,7 +3706,11 @@
     "parents": ["Gobierno de la Rioja"],
     "scope": "la_rioja",
     "type": "publico",
-    "website": "https://www.larioja.org/agricultura/es/estadistica-agraria/observatorio-precios-agrarios"
+    "website": "https://www.larioja.org/agricultura/es/estadistica-agraria/observatorio-precios-agrarios",
+    "coordinates": {
+      "lat": 42.2814642,
+      "lon": -2.482805
+    }
   },
   {
     "description": "objetivo es el impulso del despliegue de servicios de banda ancha por parte de operadores de telecomunicaciones. Esta convocatoria financia a operadores con hasta un 80% de subvención el despliegue de servicios de banda ancha de más de 300Mbps en zonas donde no existen servicios de banda ancha de más de 100Mbps. Cada operador presenta una solicitud única para cada una de las comunidades autónomas asignándose la ayuda para cada una de ellas al operador que mejor oferta presente.",
@@ -3745,7 +3765,11 @@
     "parents": ["Consejo de la Juventud"],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.juventudnavarra.es/es/observatorio-joven"
+    "website": "https://www.juventudnavarra.es/es/observatorio-joven",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Facilitar la acción intersectorial y comunitaria en salud, adaptando la información a cada contexto y cada uno de los sectores",
@@ -3880,7 +3904,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.observatoriodelainfancia.es/oia/esp/index.aspx"
+    "website": "https://www.observatoriodelainfancia.es/oia/esp/index.aspx",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "is_active": "None",
@@ -4377,7 +4405,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatori.smartcatalonia.gencat.cat/about"
+    "website": "https://observatori.smartcatalonia.gencat.cat/about",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Promover la innovación social y empresarial",
@@ -4542,7 +4574,11 @@
     "parents": ["Departament d'Empresa i Treball", "Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatoritreball.gencat.cat/ca/inici"
+    "website": "https://observatoritreball.gencat.cat/ca/inici",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatori del treball",
@@ -4604,7 +4640,11 @@
     "parents": ["Departament de Drets Socials", "Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/civisme_i_valors/observatori/"
+    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/civisme_i_valors/observatori/",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "docs": [
@@ -4618,7 +4658,11 @@
     "parents": ["Gobierno del Principado de Asturias", "Consejería de Salud"],
     "scope": "asturias",
     "type": "publico",
-    "website": "https://www.astursalud.es/noticias/-/noticias/omd"
+    "website": "https://www.astursalud.es/noticias/-/noticias/omd",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Centro educativo y divulgativo de Valencia para formar, concienciar y sensibilizar frente al cambio climático.",
@@ -4660,7 +4704,11 @@
       "Presidència. Telecomunicacions i transformació digital",
       "Generalitat de Catalunya"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Según el [DECRETO 150/2006, de 6 de octubre, del Consell, por el que se crea el Observatorio de Precios de los Productos Agroalimentarios de la Comunitat Valenciana](https://dogv.gva.es/es/resultat-dogv?signatura=2006/11596).",
@@ -4675,7 +4723,11 @@
     "name": "Observatorio de Precios de los Productos Agroalimetarios de la Comunitat Valenciana",
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://www.gva.es/es/inicio/atencion_ciudadano/buscadores/departamentos/detalle_departamentos?id_dept=14851"
+    "website": "https://www.gva.es/es/inicio/atencion_ciudadano/buscadores/departamentos/detalle_departamentos?id_dept=14851",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio de Sostenibilidad Urbana del Plan de Acción Local de la Agenda Urbana 2030 de Alcalá de Guadaíra",
@@ -4716,7 +4768,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://argos.gva.es/va/web/prospectiva/observatori"
+    "website": "https://argos.gva.es/va/web/prospectiva/observatori",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "email": "smn.obsam@cime.es",
@@ -4833,7 +4889,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://omc.cat"
+    "website": "https://omc.cat",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "De este modo en el año 2005 surge el Observatorio de la Violencia de Género, donde diariamente recopilamos, a través de los medios de comunicación, y fuentes oficiales e institucionales relacionadas con la violencia de género, noticias, opiniones e informes que puedan ser de interés no sólo para profesionales en la materia, sino para la población en su conjunto.",
@@ -4885,7 +4945,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://brechadigital.gva.es"
+    "website": "https://brechadigital.gva.es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Realiza estudios e investigaciones encaminadas a mantener actualizado el Diagnóstico Social de la ciudad, entendiendo este, como un proceso permanente de análisis social de la ciudad, en el que se enmarcan todas las publicaciones.",
@@ -4936,7 +5000,11 @@
     ],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://isek.euskadi.eus/webisek00-isekquees/es/"
+    "website": "https://isek.euskadi.eus/webisek00-isekquees/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "docs": [
@@ -5061,7 +5129,11 @@
     ],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-regional-violencia-genero"
+    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-regional-violencia-genero",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "is_active": "None",
@@ -5151,7 +5223,11 @@
     ],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://obecan.es"
+    "website": "https://obecan.es",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio de Precios Agrarios de la Región de Murcia",
@@ -5218,7 +5294,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatorisalut.gencat.cat/ca/observatori_mort"
+    "website": "https://observatorisalut.gencat.cat/ca/observatori_mort",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio de Conducta Ética de la Guardia Civil",
@@ -5279,7 +5359,11 @@
     ],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-comunidad-madrid-victimas-del-delito"
+    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-comunidad-madrid-victimas-del-delito",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "is_active": "None",
@@ -5287,7 +5371,11 @@
     "parents": ["Comunidad de Madrid", "Consejería de Sanidad"],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/servicios/salud/observatorio-resultados-servicio-madrileno-salud"
+    "website": "https://www.comunidad.madrid/servicios/salud/observatorio-resultados-servicio-madrileno-salud",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "description": "Proyecto transversal en el que participan las áreas de Deportes, Medio Ambiente, Turismo de Tenerife y Carreteras con el fin de ordenar y mejorar la situación del ciclismo en la Isla.\n\nCabildo de Tenerife",
@@ -5352,7 +5440,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://portalindustria.gva.es/es/observatorio-de-la-industria"
+    "website": "https://portalindustria.gva.es/es/observatorio-de-la-industria",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5360,7 +5452,11 @@
     "parents": ["Generalitat Valenciana", "Conselleria de Justicia e Interior"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://cjusticia.gva.es/es/web/processos-electorals/observatori-electoral"
+    "website": "https://cjusticia.gva.es/es/web/processos-electorals/observatori-electoral",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Para conocer un poco más sobre la historia de la Inteligencia Artificial, identificar a los agentes implicados y comenzar a manejarse con los términos más habituales empleados en este campo.",
@@ -5379,7 +5475,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://observatorioia.gva.es/es/"
+    "website": "https://observatorioia.gva.es/es/",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio transfronteirizo Galicia–Norte de Portugal",
@@ -5401,7 +5501,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://inclusio.gva.es/es/web/igualdad-diversidad/observatori-valencia-per-a-la-igualtat-de-trace-la-no-discriminacio-i-la-prevencio-dels-delictes-d-odi"
+    "website": "https://inclusio.gva.es/es/web/igualdad-diversidad/observatori-valencia-per-a-la-igualtat-de-trace-la-no-discriminacio-i-la-prevencio-dels-delictes-d-odi",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5412,7 +5516,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ceice.gva.es/es/web/inclusioeducativa/observatori-per-a-la-convivencia"
+    "website": "https://ceice.gva.es/es/web/inclusioeducativa/observatori-per-a-la-convivencia",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5423,7 +5531,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://brechadigital.gva.es/es"
+    "website": "https://brechadigital.gva.es/es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5431,7 +5543,11 @@
     "parents": ["Generalitat Valenciana", "Consellería de Cultura y Deporte"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ovc.gva.es/es/observatori"
+    "website": "https://ovc.gva.es/es/observatori",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5442,7 +5558,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ceice.gva.es/va/web/dg-trabajo/observatori-valencia-del-treball-decent"
+    "website": "https://ceice.gva.es/va/web/dg-trabajo/observatori-valencia-del-treball-decent",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "Sí",
@@ -5471,7 +5591,11 @@
     "name": "Observatorio de la Montaña de Aragón",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://observatoriomontanaragon.com"
+    "website": "https://observatoriomontanaragon.com",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -5479,7 +5603,11 @@
     "parents": ["Agència Tributària Valenciana"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://atv.gva.es/es/observatori-fiscal"
+    "website": "https://atv.gva.es/es/observatori-fiscal",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "email": "oasi@aragon.es",
@@ -5554,7 +5682,11 @@
     "parents": ["Hazi", "Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://behatoki.eus"
+    "website": "https://behatoki.eus",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Valenciano de las familias",
@@ -5589,7 +5721,11 @@
     "parents": ["Gobierno de Navarra", "Departamento de Salud"],
     "scope": "navarra",
     "type": "publico",
-    "website": "http://www.nafarroa.gob.es/home_es/Temas/Portal+de+la+Salud/Ciudadania/Me+cuido/Al+final+de+la+vida/Observatorio+de+la+Muerte+Digna/"
+    "website": "http://www.nafarroa.gob.es/home_es/Temas/Portal+de+la+Salud/Ciudadania/Me+cuido/Al+final+de+la+vida/Observatorio+de+la+Muerte+Digna/",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "is_active": "None",
@@ -5634,14 +5770,22 @@
     "name": "Observatorio Regional Contra la Discriminación por Orientación Sexual e Identidad de Género",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "is_active": "None",
     "name": "Observatorio Virtual del Paisaje Mediterráneo",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=9855&IDTIPO=246&RASTRO=c2195$m36284,36363"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=9855&IDTIPO=246&RASTRO=c2195$m36284,36363",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "docs": [
@@ -5663,7 +5807,11 @@
     ],
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=227&IDTIPO=200&__PLANT_PERSONALIZADA=/JSP/CARM/carm2018/organigramas/plantillaDetalleOrganigrama.jsp&IDESTRUCTURAJERARQUICA=473&RASTRO=c77$m5782"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=227&IDTIPO=200&__PLANT_PERSONALIZADA=/JSP/CARM/carm2018/organigramas/plantillaDetalleOrganigrama.jsp&IDESTRUCTURAJERARQUICA=473&RASTRO=c77$m5782",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "description": "El Observatorio de Convivencia es un conjunto de herramientas y mecanismos diversos y flexibles tanto para el análisis como para la búsqueda de respuestas a las necesidades de cohesión social de nuestra ciudad, que se adaptan a una realidad cada vez más diversa y cuya gestión resulta compleja.",
@@ -5693,7 +5841,11 @@
     "parents": ["Diputación Foral de Álava / Arabako Foru Aldundia"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://web.araba.eus/es/medio-ambiente/residuos/observatorio-de-residuos"
+    "website": "https://web.araba.eus/es/medio-ambiente/residuos/observatorio-de-residuos",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "Para analizar y difundir información sobre la evolución de los indicadores relativos a la igualdad entre mujeres y hombres, para mejorar la planificación y evaluación de las políticas públicas desde la perspectiva de género.",
@@ -5707,7 +5859,11 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://observatori-igualtat.es/es/"
+    "website": "https://observatori-igualtat.es/es/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Órgano colegiado de carácter consultivo y de impulso al desarrollo de las políticas del Gobierno de Aragón de apoyo a las familias.\n\nObjetivos\r\n- Conocer, desde una perspectiva multisectorial, la situación, calidad de vida y demandas de las familias en Aragón.\r\n- Asesorar y realizar el seguimiento de la incidencia que sobre las familias aragonesas tienen las políticas públicas.\r\n- Promover mejoras sociales, económicas y legislativas que redunden en beneficio y apoyo de las familias aragonesas.\r\n- Estimular la investigación y el conocimiento de la realidad socio-económica de las familias en Aragón.\n\nGobierno de Aragón",
@@ -5936,7 +6092,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragoncambioclimatico.es/observatorio/"
+    "website": "https://www.aragoncambioclimatico.es/observatorio/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "STO Mallorca nace en el marco del [Plan de Recuperación, Transformación y Resiliencia del Gobierno de España](https://www.mincotur.gob.es/es-es/recuperacion-transformacion-resiliencia/paginas/plan-recuperacion-transformacion-resiliencia.aspx) con los fondos europeos Next Generation EU alineados con el plan estratégico de la FMT.\n\nEl Observatorio de Turismo Sostenible de Mallorca tiene como misión generar información de valor que permita guiar las decisiones del sector público y privado, dotando de inteligencia toda la cadena de valor de forma que se incrementa su competitividad y productividad, teniendo siempre en consideración los principios directores de la sostenibilidad.\n\nEl Observatorio de Turismo Sostenible de Mallorca tiene como misión generar información de valor que permita guiar las decisiones del sector público y privado, dotando de inteligencia toda la cadena de valor de forma que se incrementa su competitividad y productividad, teniendo siempre en consideración los principios directores de la sostenibilidad.\n\n- La Agencia de Estrategia Turística de las Islas Baleares (AETIB)\r\n- La Federación de Entidades Locales de las Islas Baleares (FELIB)\r\n- La Cámara de Comercio de Mallorca\r\n- AENA (Aeropuertos Españoles y Navegación Aérea)\r\n- La Autoridad Portuaria de Baleares (APB)\r\n- La Agencia Estatal de Meteorología (AEMET)\r\n- El Instituto de Estadística de las Illes Balears (IBESTAT)\r\n- Federación Empresarial Hotelera de Mallorca\r\n- Agrupación de Cadenas Hoteleras Baleares\r\n- Agrupación Empresarial de Agencias de Viaje de Baleares\r\n- Creado en 1905, Fomento del Turismo de Mallorca\r\n- La Fundación Impulsa Balears\r\n- El clúster internacional de las Tecnologías de la Información y la Comunicación aplicadas al Turismo (TURISTEC)\r\n- La Universitat de les Illes Balears (UIB)",
@@ -6059,7 +6219,11 @@
     "parents": ["Diputación de Cáceres"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://observatoriodipcc.dip-caceres.es/"
+    "website": "https://observatoriodipcc.dip-caceres.es/",
+    "coordinates": {
+      "lat": 39.4745175,
+      "lon": -6.3716761
+    }
   },
   {
     "name": "Observatorio de Buenas Prácticas Regulatorias",
@@ -6439,7 +6603,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dataraba.eus"
+    "website": "https://www.dataraba.eus",
+    "coordinates": {
+      "lat": 42.8440723,
+      "lon": -2.6820829
+    }
   },
   {
     "description": "Aquest projecte va néixer a la UIB l'any 2008 com a resultat del conveni de col·laboració entre el Govern Balear i la Universitat de les Illes Balears en matèria de serveis socials. Aquella primera etapa es va desenvolupar entre 2008 i 2012. Ara, en un context difícil de nou, la Universitat de les Illes Balears, a través de la Càtedra d’Innovació Social “la Caixa”, dóna un nou impuls a l'Observatori Social de les Illes Balears, amb l’objectiu de recollir i generar informació per millorar el coneixement de la situació social de Mallorca, Menorca, Eivissa i Formentera i detectar situacions emergents, punts crítics i respostes innovadores que facilitin la cohesió i la justícia social.",
@@ -6463,7 +6631,11 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://osib.uib.cat"
+    "website": "https://osib.uib.cat",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Anunciado el 4 de julio de 2024 sin más detalles. Enmarcado en una subvención de 150.000 € para el Programa de Segunda Oportunidad del Gobierno de Aragón.",
@@ -6475,7 +6647,11 @@
     ],
     "scope": "aragon",
     "type": "mixto",
-    "website": "https://www.aragonhoy.es/vicepresidencia-segunda-economia-empleo-industria/gobierno-aragon-sella-ata-upta-acuerdo-desarrollar-programa-segunda-oportunidad-96693"
+    "website": "https://www.aragonhoy.es/vicepresidencia-segunda-economia-empleo-industria/gobierno-aragon-sella-ata-upta-acuerdo-desarrollar-programa-segunda-oportunidad-96693",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Iniciativa de la Dirección General de Protección de Consumidores y &nbsp;Usuarios y de la Universidad de Zaragoza para, en el marco de las líneas de investigación ya consolidadas, dar un nuevo paso en el servicio a los consumidores aragoneses, integrando la información existente en las bases de datos del Centro de Información y Documentación Aragonés de Consumo (CIDAC) —señaladamente la información de prensa y los estudios realizados por otras entidades— y el Sistema de Información de Consumo —fundamentalmente los datos sobre consultas, reclamaciones y denuncias, campañas y arbitraje—, y completándola con información procedente de forma directa del consumidor — mediante encuestas.",
@@ -6533,27 +6709,47 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://www.caib.es/sites/objib/es/inici-33505/"
+    "website": "https://www.caib.es/sites/objib/es/inici-33505/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "name": "Observatorio Vasco del Comercio",
     "scope": "pais_vasco",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de los Servicios Sociales",
     "scope": "pais_vasco",
-    "website": "https://www.behatuz.eus/es/"
+    "website": "https://www.behatuz.eus/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de la Cadena Alimentaria de Euskadi",
     "scope": "pais_vasco",
-    "website": "https://behatoki.eus/"
+    "website": "https://behatoki.eus/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Mujer Empresa",
     "scope": "pais_vasco",
-    "website": "https://www.aedbiz.org/observatorio-aed/"
+    "website": "https://www.aedbiz.org/observatorio-aed/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio y Consejo Social para el Reto Demográfico",
@@ -6761,7 +6957,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2019"
+    "from_date": "2019",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Regional del Cambio Climático",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -479,7 +479,11 @@
     "parents": ["Consejeria de Agricultura y Pesca", "Junta de Andalucia"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/agriculturaypesca/observatorio"
+    "website": "https://www.juntadeandalucia.es/agriculturaypesca/observatorio",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Su misión es <q>Generar información relevante y de calidad a políticos, gestores, investigadores, profesionales de la salud y a la sociedad civil en general con el fin de mejorar las políticas, programas y servicios sanitarios-sociosanitarios de forma que respondan equitativa y eficientemente a las necesidades de salud de la población y a la reducción de las desigualdades en salud en Cantabria</q>.",
@@ -582,7 +586,11 @@
     "parents": ["Instituto Aragonés de la Juventud"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/presentacion-1"
+    "website": "https://www.aragon.es/-/presentacion-1",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "IBERIFIER es un observatorio de medios digitales de España y Portugal, impulsado por la Comisión Europea y vinculado al [European Digital Media Observatory](https://edmo.eu/) (EDMO). Coordinado desde la Universidad de Navarra, está integrado por doce universidades, cinco organizaciones de verificación y agencias de noticias, y seis centros de investigación multidisciplinar.",
@@ -739,7 +747,11 @@
       "Instituto Universitario de Economía Social y Cooperativa",
       "Universidad de Valencia"
     ],
-    "website": "http://www.observatorioeconomiasocial.es"
+    "website": "http://www.observatorioeconomiasocial.es",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio Español de las Drogas y las Adicciones",
@@ -775,7 +787,11 @@
         "name": "Informe de tendencias en biotecnología"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio Español del Racismo y la Xenofobia",
@@ -874,7 +890,11 @@
         "name": "[Nº22 Abril-Junio 2022](https://www.navarra.es/documents/45973623/45979584/segundo+trimestre+2022.pdf/7a288214-2147-7736-c505-260ef7821f56?t=1734698990976)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio Socioeconómico aporta la información necesaria para el diagnóstico a los procesos de planificación, facilitando indicadores de evolución socioeconómica al personal técnico que trabaja en desarrollo local.\n\n- Diputación Provincial de Cáceres",
@@ -914,7 +934,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Se ofrece un formulario de contacto.",
-    "from_date": "2014"
+    "from_date": "2014",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "description": "La función del observatorio es la investigación, análisis y desarrollo de soluciones para abordar el problema de la soledad en la región de Aragón.\n\nEl observatorio aragonés de la soledad está compuesto por los siguientes organismos:\n\nGobierno de Aragón\r\nFederación aragonesa de municipios, comarcas y provincias\r\nAyuntamiento de Zaragoza.\r\nConsejo aragonés de personas mayores.\r\nColegio profesional de trabajo social en Aragón.",
@@ -938,7 +962,11 @@
     "name": "Observatorio de la Convivencia Escolar",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.educa.jcyl.es/convivenciaescolar/es/observatorio-convivencia-escolar"
+    "website": "https://www.educa.jcyl.es/convivenciaescolar/es/observatorio-convivencia-escolar",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio TransfomAcción y ParticipAcción",
@@ -997,7 +1025,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://barcelonadadescultura.bcn.cat/?lang=es"
+    "website": "https://barcelonadadescultura.bcn.cat/?lang=es",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Observatorio de la lengua española y las culturas hispánicas en los Estados Unidos",
@@ -1227,7 +1259,11 @@
     "parents": ["Ayuntamiento de Gijón"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.gijon.es/es/observatorio_empleo?observatorio=Sociedades%20Mercantiles%20constituidas"
+    "website": "https://www.gijon.es/es/observatorio_empleo?observatorio=Sociedades%20Mercantiles%20constituidas",
+    "coordinates": {
+      "lat": 43.5449422,
+      "lon": -5.66275
+    }
   },
   {
     "name": "Observatorio Nacional de las Telecomunicaciones y de la Sociedad de la Información",
@@ -1452,7 +1488,11 @@
   {
     "name": "Observatorio Argos de la Junta de Andalucía",
     "scope": "andalucia",
-    "website": "https://www.juntadeandalucia.es/servicioandaluzdeempleo/web/argos/web/es/ARGOS/index.html"
+    "website": "https://www.juntadeandalucia.es/servicioandaluzdeempleo/web/argos/web/es/ARGOS/index.html",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "OTALEX está financiado por el programa europeo INTERREGIII A y tiene marcado como objetivo estudiar y mostrar la realidad de un territorio, compuesto por las regiones del **Alentejo** en Portugal y **Extremadura** en España, separado convencionalmente por una frontera administrativa pero unido por sus características físicas, ambientales, sociales y económicas. Se trata de espacios rurales de baja densidad demográfica donde los recursos naturales, culturales y la calidad ambiental conforman sus atractivos fundamentales.\n\nLa IDE OTALEX es el resultado del esfuerzo, el compromiso y la colaboración entre instituciones a los dos lados de la frontera, con implicación de los tres niveles administrativos: Estatal, Regional y Local. Muestra los trabajos de homogeneización y estandarización de datos del territorio Alentejo-Extremeño, a través de clientes de visualización de mapas, consulta de topónimos y consulta de catálogo, dentro de las líneas de INSPIRE.\n\n- Gobierno de Extremadura (Ordenación del Territorio)\r\n- Diputación de Cáceres (Área de Desarrollo Local y Formación)\r\n- Diputación de Badajoz\r\n- Instituto Geográfico Nacional\r\n- Comunidade Intermunicipal do Alentejo Central\r\n- Comunidade Intermunicipal do Alto Alentejo\r\n- Direção-Geral do Território (PT)\r\n- Universidad de Extremadura\r\n- Comissão de Coordenação e Desenvolvimento Regional do Alentejo\r\n- Empresa de Desenvolvimento de Infra-estruturas do Alqueva, S.A\r\n- Univerisdade de Évora\r\n- Instituto Politécnico de Castelo Branco",
@@ -1548,7 +1588,11 @@
         "name": "Directorio de la red del Observatorio de las Ocupaciones — SEPE (Dirección Provincial de Asturias)",
         "url": "https://www.sepe.es/HomeSepe/que-es-el-sepe/que-es-observatorio/Directorio-red-Observatorio.html"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "El Observatorio Social Barcelona es un instrumento de conocimiento de la realidad social de la ciudad que tiene como objetivos principales: Conocer y evaluar la situación y la evolución de las condiciones de vida de la población, la realidad de los diferentes colectivos y la evolución de los fenómenos y procesos sociales que afectan a la calidad de vida de las personas y a la cohesión social de la ciudad. Difundir y compartir conocimiento con la ciudadanía, las entidades y asociaciones, y con el colectivo profesional y técnico, directivo y político. Apoyar a la planificación y a la toma de decisiones.",
@@ -1556,7 +1600,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://ajuntament.barcelona.cat/dretssocials/es/content/observatorio-social-bcn"
+    "website": "https://ajuntament.barcelona.cat/dretssocials/es/content/observatorio-social-bcn",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Espacio de Observación de Inteligencia Artificial (IA) en español",
@@ -1665,7 +1713,11 @@
         "name": "https://ildefe.es/wp-content/uploads/2024/05/InformeMercadoLaboral_informecompleto1T24.pdf"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.5989995,
+      "lon": -5.5682413
+    }
   },
   {
     "name": "Observatorio del Sector TIC en Extremadura",
@@ -1703,7 +1755,11 @@
         "name": "[INFORME DE EVOLUCIÓN DE LA POLÍTICA AGRARIA COMÚN 2016](https://observatorioagrario.navarra.es/documents/30155142/31265379/Informe+PAC+2016-2019.pdf/eca94454-c936-2f21-304b-53279a5f4e51?t=1706606695550)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio FIEX de las Familias y la Infancia de Extremadura",
@@ -1784,7 +1840,11 @@
     "scope": "local",
     "from_date": "20/02/2025",
     "parents": ["Ajuntament de Reus"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.1555564,
+      "lon": 1.1076133
+    }
   },
   {
     "name": "Observatorio de Responsabilidad Social de Extremadura",
@@ -2353,7 +2413,11 @@
     "parents": ["Mercamadrid", "Ayuntamiento de Madrid"],
     "scope": "local",
     "type": "mixto",
-    "website": "https://www.mercamadrid.es/observatorio-tendencias-hosteleria/"
+    "website": "https://www.mercamadrid.es/observatorio-tendencias-hosteleria/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
@@ -2564,7 +2628,11 @@
       {
         "name": "Informes anuales sobre la evolución del hecho inmigratorio desde los puntos de vista demográfico, económico-laboral, y de la opinión pública"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de Innovación de Navarra - Nafarroako Berrikuntzaren Behatokia",
@@ -2592,7 +2660,11 @@
         "name": "Estudio evolutivo de la Encuesta FECYT en Navarra"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio de Igualdad del IIS Galicia Sur",
@@ -2781,7 +2853,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/cultura/flamenco/content/observatorio-del-flamenco"
+    "website": "https://www.juntadeandalucia.es/cultura/flamenco/content/observatorio-del-flamenco",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Es un foro de debate, de análisis crítico, de reflexión y generador de propuestas de actuaciones para avanzar en un modelo de sociedad en el que la vivienda cumpla con las características que se recogen en la Nueva Agenda Urbana, un modelo de ciudad en que se facilite el acceso a una vivienda digna accesible, eficiente, sostenible y en el que quepamos por igual.",
@@ -2800,7 +2876,11 @@
     ],
     "scope": "cantabria",
     "to_date": "parece que en 2021 \"muere\"",
-    "website": "https://www.observatoriovivienda.cantabria.es"
+    "website": "https://www.observatoriovivienda.cantabria.es",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "Para <q>aumentar el nivel de “empleabilidad” de nuestro estudiantado y colectivo <i>alumni</i></q>.",
@@ -2882,7 +2962,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/agp/sgt/temas/estadistica/CM-observatorio.html"
+    "website": "https://www.gobiernodecanarias.org/agp/sgt/temas/estadistica/CM-observatorio.html",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "Según su web\r\nLa promoción de iniciativas para contribuir al desarrollo sostenible del medio rural\r\nSensibilizar y dinamizar al población del medio rural y local sobre la capacidad de los territorios de establecer procesos autónomos de desarrollo y cambio a partir de los recursos y potencialidades endógena.\r\nParticipar apoyando activamente los procesos de desarrollo que se desarrollen en ámbitos locales y rurales.\r\nIntegrar diferentes áreas de conocimiento en el análisis y la intervención en el desarrollo local y rural.\r\nContribuir y promover procesos de planificación estratégica en ámbitos locales y rurales.\r\nPromover y mejorar la gobernanza en ámbitos locales y rurales.\n\nLo que se ve: Un par de informes y la estadística de datos de empleo, tomados de otras fuentes\n\nUniversidad de Murcia",
@@ -2897,7 +2981,11 @@
     "scope": "autonómico",
     "to_date": "Desde 2017 no se incluyen nuevos informes\r\nAparecen páginas con datos actualizados, pero parecen páginas zombis que funcionan solas",
     "type": "publico",
-    "website": "https://www.um.es/observalocal/"
+    "website": "https://www.um.es/observalocal/",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "description": "El Observatorio de la desigualdad se concibe para que Aragón pueda dotarse de herramientas adecuadas para generar indicadores estables de desigualdad en diversos ámbitos, que faciliten un análisis informado y nutran el debate social sobre estas cuestiones.",
@@ -2923,7 +3011,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-de-desigualdad-de-aragon"
+    "website": "https://www.aragon.es/-/observatorio-de-desigualdad-de-aragon",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Tiene como objetivo <q>disponer de información para el seguimiento y el análisis de los márgenes empresariales y de mejorar el conocimiento sobre su evolución y sus implicaciones para el conjunto de la economía</q>.",
@@ -2991,7 +3083,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/educacion/portals/web/convivencia-escolar/estructura-y-funcionamiento"
+    "website": "https://www.juntadeandalucia.es/educacion/portals/web/convivencia-escolar/estructura-y-funcionamiento",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "El Observatorio del Sistema Penal y los Derechos Humanos (OSPDH) de la Universidad de Barcelona es un Centro de Investigación, creado en el mes de mayo de 2001, integrado por profesores/as universitarios de la UB y otras Universidades nacionales, de Europa y de América Latina, así como por profesionales de instituciones y organizaciones de defensa de derechos humanos, estudiantes avanzados de programas de postgrado y doctorados y activistas que se desempeñan en la lucha por la promoción de derechos y garantías básicas.",
@@ -3002,7 +3098,11 @@
     "parents": ["Universitat de Barcelona"],
     "scope": "barcelona",
     "type": "publico",
-    "website": "https://www.ub.edu/portal/web/observatori-sistema-penal/presentacio"
+    "website": "https://www.ub.edu/portal/web/observatori-sistema-penal/presentacio",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Promover, impulsar y apoyar el conocimiento de los mercados nacional e internacionales del vino y los productos vitivinícolas, en todos sus ámbitos y canales, incluyendo especificidades relativas a distribución y consumidores. Ver [Sobre nosotros](https://www.oemv.es/sobre-nosotros)\n\nMinisterio de Agricultura, Pesca y Alimentación\r\nICEX\r\nFederación Española del Vino",
@@ -3055,7 +3155,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/economia/ocea/"
+    "website": "https://www.gobiernodecanarias.org/economia/ocea/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -5354,7 +5458,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://obsaludasturias.com/obsa"
+    "website": "https://obsaludasturias.com/obsa",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "El Observatorio de la Calidad de Tenerife es una iniciativa del Cabildo Insular, orientada al estudio, análisis y evolución de las nuevas tendencias y modelos de calidad de gestión en el ámbito nacional e internacional, dirigida especialmente a monitorizar y fomentar la implantación de la calidad en Tenerife.\n\nCabildo de Tenerife",
@@ -5363,7 +5471,11 @@
     "parents": ["Cabildo de Tenerife"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.calidadtenerife.org"
+    "website": "https://www.calidadtenerife.org",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "El Observatorio de la Publicidad e Información no Sexista nace para recoger todas aquellas quejas o denuncias que puedan atentar contra la imagen o dignidad de las mujeres en medios de comunicación y/o publicitarios.\n\nInstituto Asturiano de la Mujer.",
@@ -5390,7 +5502,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://iam.asturias.es/observatorio-de-la-publicidad-e-informacion-no-sexista"
+    "website": "https://iam.asturias.es/observatorio-de-la-publicidad-e-informacion-no-sexista",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Sistema de información que permita la adecuada dirección, planificación y evaluación de los servicios sociales.\n\nLa creación del Observatorio Asturiano de Servicios Sociales tiene la finalidad de:\r\n-Aportar y analizar información que permita un mejor conocimiento de la situación de los servicios sociales del Principado de Asturias con el fin favorecer la toma de decisiones en el diseño y desarrollo de políticas sociales.\r\n-Asesorar a la Dirección General con competencia en materia de planificación de servicios sociales en el ejercicio de sus funciones como unidad estadística.\r\n-Facilitar la labor a profesionales del ámbito técnico y/o científico relacionados con los servicios sociales.\r\n-Materializar el derecho que tiene la ciudadanía de acceso a la información que obra en poder de la Administración sobre los servicios que presta y de su impacto en la sociedad.\n\nSe organiza en un Consejo Rector y una Comisión Asesora cuya composición se detalla en el [Decreto 35/2017, de 31 de mayo, por el que se crea y se regula el Observatorio Asturiano de Servicios Sociales (OBSERVASS)], BOPA 132 de 9-vi-2017 (https://sede.asturias.es/bopa/2017/06/09/2017-06449.pdf)",
@@ -6124,7 +6240,11 @@
     "parents": ["Diputación Provincial de Zaragoza", "Universidad de Zaragoza"],
     "scope": "provincial",
     "type": "mixto",
-    "website": "https://ocatcodes.unizar.es"
+    "website": "https://ocatcodes.unizar.es",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Observatorio de Competencias Digitales y Empleabilidad",
@@ -6220,7 +6340,11 @@
     "website": "https://www.xunta.gal/es/notas-de-prensa/-/nova/007512/xunta-adjudica-nuevo-observatorio-sostenibilidad-turistica-que-permitira-monitorizar",
     "scope": "autonómico",
     "from_date": "22 de noviembre de 2024",
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Transfronterizo España-Portugal",
@@ -6299,7 +6423,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2020"
+    "from_date": "2020",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Regional de Discapacidad",
@@ -6316,7 +6444,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2009"
+    "from_date": "2009",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de las Masculinidades",
@@ -6523,7 +6655,11 @@
       }
     ],
     "is_active": "Sí",
-    "email": "info@faen.es"
+    "email": "info@faen.es",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Bizkaiko Behatokia",
@@ -6681,7 +6817,11 @@
     "type": "publico",
     "website": "https://www.visitmadrid.es/observatorio-turistico-comunidad-madrid",
     "is_active": "Sí",
-    "email": "No disponible"
+    "email": "No disponible",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Regional de Seguridad del Paciente",
@@ -6813,7 +6953,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "Más de 10 años (estaciones desde 1990)"
+    "from_date": "Más de 10 años (estaciones desde 1990)",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio forestal",
@@ -6859,7 +7003,11 @@
         "url": "https://www.madrid.es/portales/munimadrid/es/Inicio/Actividad-economica-y-hacienda/Observatorio-economico/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Municipal contra la LGTBIfobia (Madrid)",
@@ -6869,7 +7017,11 @@
     "type": "publico",
     "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/Buscador/Observatorio-Municipal-contra-la-LGTBIfobia/",
     "is_active": "Sí",
-    "from_date": "2021-12-28"
+    "from_date": "2021-12-28",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatori Metropolità de l’Habitatge de Barcelona (O-HB)",
@@ -6884,7 +7036,11 @@
     "type": "publico",
     "website": "https://www.ohb.cat/",
     "is_active": "Sí",
-    "from_date": "2017"
+    "from_date": "2017",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Observatori Social Barcelona",
@@ -6912,7 +7068,11 @@
         "url": "https://www.bilbaoekintza.eus/conocenos/areas-de-accion/observatorio"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 43.2630018,
+      "lon": -2.9350039
+    }
   },
   {
     "name": "Observatorio del Plan Estratégico de Sevilla 2030",
@@ -6945,7 +7105,11 @@
         "url": "https://climaienergia.com/es/observatori/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio de Salud Urbana de València",
@@ -6985,7 +7149,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2008"
+    "from_date": "2008",
+    "coordinates": {
+      "lat": 41.6521807,
+      "lon": -4.728605
+    }
   },
   {
     "name": "Observatorio Municipal de Inmigración (Valladolid)",
@@ -7003,7 +7171,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2006"
+    "from_date": "2006",
+    "coordinates": {
+      "lat": 41.6521807,
+      "lon": -4.728605
+    }
   },
   {
     "name": "Observatorio Municipal de Estadística (Zaragoza)",
@@ -7018,7 +7190,11 @@
         "url": "https://www.zaragoza.es/sede/portal/observatorio/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Cátedra de Territorio, Sociedad y Visualización Geográfica (Zaragoza)",
@@ -7028,7 +7204,11 @@
     "type": "mixto",
     "website": "https://www.zaragoza.es/sede/portal/participacion/catedra/territorio/",
     "is_active": "Sí",
-    "from_date": "2016"
+    "from_date": "2016",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Observatorio de Vivienda de Leganés",
@@ -7075,7 +7255,11 @@
     "scope": "andalucia",
     "type": "mixto",
     "is_active": "No",
-    "from_date": "Anunciado"
+    "from_date": "Anunciado",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio para el Impulso Demográfico",
@@ -7099,7 +7283,11 @@
     "parents": ["Diputación de Segovia"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia"
+    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia",
+    "coordinates": {
+      "lat": 40.9481192,
+      "lon": -4.1172101
+    }
   },
   {
     "name": "Observatori de la Qualitat de l'Aire del Camp de Tarragona (OQACT)",
@@ -7107,7 +7295,11 @@
     "parents": ["Institut Cerdà", "Repsol", "AEQT"],
     "scope": "cataluna",
     "type": "mixto",
-    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/"
+    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/",
+    "coordinates": {
+      "lat": 41.1172364,
+      "lon": 1.2546057
+    }
   },
   {
     "name": "OTIGRAN (Observatorio Turístico de Gran Canaria)",
@@ -7325,7 +7517,11 @@
     "parents": ["Diputación de Segovia"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica"
+    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica",
+    "coordinates": {
+      "lat": 41.4867788,
+      "lon": -3.5219055
+    }
   },
   {
     "name": "Observatorio Local de Sostenibilidad de Albacete (OLSA)",
@@ -7349,7 +7545,11 @@
     ],
     "scope": "provincial",
     "type": "mixto",
-    "website": "https://www.observatorioeconomicosevilla.com/"
+    "website": "https://www.observatorioeconomicosevilla.com/",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Indicadores de Administración Digital (Ayuntamiento de Madrid)",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -157,7 +157,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://despoblacionguadalajara.es/"
+    "website": "https://despoblacionguadalajara.es/",
+    "coordinates": {
+      "lat": 40.7399963,
+      "lon": -2.50593
+    }
   },
   {
     "description": "Este organismos pretende poner en valor el patrimonio natural-ambiental de los casi 500 ríos de Galicia, que funcionará como un órgano de asesoramiento sobre el estado ambiental, económico, social y cultural de los rios.<br/>No ha sido posible encontrar información sobre si el observatorio está activo o no, tampoco sobre su actividad, si la tuviere.",
@@ -338,7 +342,11 @@
     "parents": ["Ayuntamiento de Fuenlabrada"],
     "scope": "local",
     "type": "publico",
-    "website": "https://cife.ayto-fuenlabrada.es/observatorio-local-empleo-fuenlabrada/"
+    "website": "https://cife.ayto-fuenlabrada.es/observatorio-local-empleo-fuenlabrada/",
+    "coordinates": {
+      "lat": 40.282476,
+      "lon": -3.7923422
+    }
   },
   {
     "name": "Observatorio de la Infancia de Cataluña / Observatori dels Drets dels Infants",
@@ -615,7 +623,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://agrobservex.juntaex.es/"
+    "website": "https://agrobservex.juntaex.es/",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "description": "El Observatorio de Igualdad de la CRTVE vela por el cumplimiento de los compromisos legales en materia de igualdad de la corporación, haciendo un seguimiento de los contenidos de RTVE y garantizando en ellos el respeto a la igualdad entre mujeres y hombres. Su objetivo es que la corporación sea referente en la defensa de la igualdad y la lucha para la erradicación de la violencia contra las mujeres.",
@@ -978,7 +990,11 @@
       {
         "url": "https://startupvalencia.org/es/descarga-informe-observatorio/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio Galego de Dinamización Demográfica",
@@ -1028,7 +1044,11 @@
     "is_active": "No",
     "name": "Observatorio Nacional contra el Despoblamiento",
     "parents": ["Gobierno de Cantabria", "Ayuntamiento de Valderredible"],
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 42.8564085,
+      "lon": -3.9708898
+    }
   },
   {
     "docs": [
@@ -1588,7 +1608,11 @@
     "description": "El Observatorio Extremeño de las TIC es una plataforma que recopila, analiza y difunde información sobre el uso de las tecnologías de la información y la comunicación (TIC) en Extremadura. La información que se comparte, pretende ayudar a las personas lectoras a comprender el histórico y la situación actual de la región extremeña respecto a las TIC y generar una visión completa de hacia dónde evoluciona nuestra región en materia digital y tecnológica.",
     "scope": "extremadura",
     "type": "publico",
-    "website": "https://extremaduradigital.org/"
+    "website": "https://extremaduradigital.org/",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio Agrario",
@@ -1624,7 +1648,11 @@
     "type": "publico",
     "email": "info@obsevatoriofiex.es",
     "website": "https://observatoriofiex.es/observatorio-fiex/",
-    "description": "Para el estudio y análisis de la realidad social de las familias extremeñas, junto con el asesoramiento a los poderes públicos en relación a las políticas de apoyo a estas familias"
+    "description": "Para el estudio y análisis de la realidad social de las familias extremeñas, junto con el asesoramiento a los poderes públicos en relación a las políticas de apoyo a estas familias",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Derechos Digitales",
@@ -1638,7 +1666,11 @@
     "name": "Observatorio para la Convivencia Escolar de Extremadura",
     "scope": "extremadura",
     "website": "https://www.educarex.es/convivencia/observatorio-convivencia-escolar-02.html",
-    "parents": ["Secretaría General de Educación"]
+    "parents": ["Secretaría General de Educación"],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Prevención de Riesgos Laborales de la Comunidad Autónoma de la Región de Murcia",
@@ -1649,7 +1681,11 @@
   },
   {
     "name": "Observatorio de Turismo de Extremadura",
-    "scope": "extremadura"
+    "scope": "extremadura",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio Extremeño de la Cultura",
@@ -1698,7 +1734,11 @@
         "name": "Difusión sobre la calificación e inscripción RSE (nota en ExtremaduraEmpresarial)",
         "url": "https://www.extremaduraempresarial.es/2025/05/02/que-beneficios-aporta-la-calificacion-como-empresa-socialmente-responsable-de-extremadura/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio sobre Drogas de la Región de Murcia",
@@ -2151,7 +2191,11 @@
         "name": "¿Cuáles son las experiencias de discriminación de las personas migrantes en Tenerife?"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 28.4857715,
+      "lon": -16.3159422
+    }
   },
   {
     "name": "Observatorio de Coyuntura Industrial",
@@ -2185,7 +2229,11 @@
     ],
     "is_active": "Sí",
     "email": "info@ikuspegi.eus",
-    "from_date": "2004"
+    "from_date": "2004",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Turístico de la Provincia de Sevilla",
@@ -2227,7 +2275,11 @@
     "name": "Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://administracion.gob.es/pagFront/espanaAdmon/directorioOrganigramas/fichaUnidadOrganica.htm?idUnidOrganica=138480&origenUO=comunidadesAutonomas&volver=volverFicha&imprimir=1"
+    "website": "https://administracion.gob.es/pagFront/espanaAdmon/directorioOrganigramas/fichaUnidadOrganica.htm?idUnidOrganica=138480&origenUO=comunidadesAutonomas&volver=volverFicha&imprimir=1",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "description": "El Observatorio de Precios es una herramienta de seguimiento y análisis de los precios en origen de los principales productos agrícolas y ganaderos de Castilla y León.\n\nSeguirlos y analizarlos con el máximo rigor y transparencia hará posible prever y detectar a tiempo las oscilaciones y desequilibrios entre la oferta y la demanda, lo que permitirá tomar las decisiones más correctas para mantener el equilibrio entre todos sus componentes y, en último término, podrá evitar que los consumidores asuman un sobrecoste injustificado y contribuirá a que los agricultores y ganaderos obtengan una retribución justa por sus producciones.\n\nEl Observatorio muestra los precios en origen de aquellos productos agrícolas y ganaderos en los que Castilla y León ocupa una posición relevante en el ámbito nacional por ser una de las principales productoras o por la calidad diferenciada de su producción, sin perjuicio de que paulatinamente puede ofrecerse información sobre más productos.",
@@ -2242,7 +2294,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://agriculturaganaderia.jcyl.es/web/es/estadistica-informacion-agraria/observatorio.html#:~:text=El%20Observatorio%20muestra%20los%20precios%20en%20origen%20de,que%20paulatinamente%20puede%20ofrecerse%20informaci%C3%B3n%20sobre%20m%C3%A1s%20productos."
+    "website": "https://agriculturaganaderia.jcyl.es/web/es/estadistica-informacion-agraria/observatorio.html#:~:text=El%20Observatorio%20muestra%20los%20precios%20en%20origen%20de,que%20paulatinamente%20puede%20ofrecerse%20informaci%C3%B3n%20sobre%20m%C3%A1s%20productos.",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Administración Electrónica Ayuntamiento de Ciudad Real",
@@ -2252,7 +2308,11 @@
     "scope": "local",
     "from_date": "Octubre 2025",
     "parents": ["Ayuntamiento de Ciudad Real"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 38.9597348,
+      "lon": -3.8828744
+    }
   },
   {
     "name": "Observatorio Vasco LGTBI+",
@@ -2599,7 +2659,11 @@
     ],
     "scope": "local",
     "type": "mixto",
-    "website": "alasacoruna.org/observatorio-corunes-contra-la-lgtbifobia/"
+    "website": "alasacoruna.org/observatorio-corunes-contra-la-lgtbifobia/",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    }
   },
   {
     "description": "Para <q>la obtención y análisis sistemático de información y datos objetivos del sector necesario para conocer su historia, estructura, impacto económico y realidad actual del arte jondo, así como una herramienta para su evaluación</q>.",
@@ -3316,7 +3380,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.obcp.es"
+    "website": "https://www.obcp.es",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "impulsar el espíritu comercial y transmitirlo a todo el colectivo empresarial de la provincia de Alicante y su hinterland.\n\nse crea este Observatorio Comercial con el que se persigue producir, recopilar y evaluar información referente a la actividad económica y logística de la provincia, así como de los flujos de transporte marítimo exterior, con el fin de poder ofrecer un servicio del Puerto de Alicante más atractivo para el tejido empresarial y acorde a sus necesidades\n\nAutoridad Portuaria de Alicante\r\nComunidad Portuaria\r\nCámara de Comercio\r\nComunidad Empresarial\r\nComunidad Marítima\r\nComunidad Logística Portuaria",
@@ -3382,7 +3450,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://comercio.castillalamancha.es/observatorio-comercio"
+    "website": "https://comercio.castillalamancha.es/observatorio-comercio",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "docs": [
@@ -3471,7 +3543,11 @@
       "Junta de Castilla-La Mancha"
     ],
     "scope": "castilla_la_mancha",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "L’Observatori es configura com un òrgan tècnic adscrit al Departament de Justícia, Drets i Memòria i dependent del Centre d’Estudis Jurídics i Formació Especialitzada, que n’aportarà la infraestructura i el suport administratiu, tècnic i logístic necessari perquè pugui dur a terme la seva activitat, i està dotat pressupostàriament amb fons del Pacte d’Estat contra la Violència de Gènere.\n\nÉs un repte pel CEJFE posar en marxa aquest Observatori i fer-ne d’ell un instrument que ajudi a millorar la resposta de l’administració de justícia i de l’execució penal davant el fenomen de les violències masclistes, amb la finalitat d’aproximar aquest coneixement a la lluita per a la seva erradicació. Així, l’Observatori constitueix un fòrum d'anàlisi, reflexió, debat, participació i proposta d'actuació en matèries relacionades amb la violència masclista a Catalunya.\n\nTotes les activitats gestionades per l’Observatori estan finançades a càrrec del crèdits rebuts del Ministeri d’Igualtat (Secretaria d’Estat d’Igualtat i contra la Violència de Gènere).",
@@ -3572,7 +3648,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://plagas.itacyl.es"
+    "website": "https://plagas.itacyl.es",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "description": "El Observatorio dispondrá de una página en la web del Colegio de arquitectos [www.coacmto.com](https://coacmto.com/coacmto-sede-y-horario-colegio-oficial-de-arquitectos-castilla-la-mancha) donde se informará de las actividades, noticias o jornadas que se programen y dispondrá de un sencillo formulario de inscripción abierto a ciudadanos, profesionales, asociaciones, entidades públicas o privadas que estén interesados en participar en esta iniciativa.",
@@ -3584,7 +3664,11 @@
       "Empresa Municipal de Suelo y Vivienda de Toledo"
     ],
     "scope": "castilla_la_mancha",
-    "website": "https://coacmto.com/observatorio-vivienda-colaborativa-toledo"
+    "website": "https://coacmto.com/observatorio-vivienda-colaborativa-toledo",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Recoge infracciones y casos de malas prácticas en la minería a partir de las denuncias realizadas por la ciudadanía y los colectivos sociales.",
@@ -3653,7 +3737,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://obafi.es"
+    "website": "https://obafi.es",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "name": "Observatorio contra la Soledad No Deseada (SND)",
@@ -3677,7 +3765,11 @@
         "url": "https://trescantosplus.es/ii-sesion-del-observatorio-contra-la-soledad-no-deseada-en-las-personas-mayores/"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.6012354,
+      "lon": -3.7038475
+    }
   },
   {
     "description": "El IPEX, como organismo dependiente de la Consejería de Economía, Empresas y Empleo, encargado de la promoción internacional de las empresas de Castilla-La Mancha, pone en marcha esta oficina de atención virtual que atiende a las empresas de la región para resolver tus dudas sobre el Brexit.",
@@ -3690,7 +3782,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://ipex.es/global-news/articulos-de-interes/observatorio-de-castilla-la-mancha-sobre-el-brexit/"
+    "website": "https://ipex.es/global-news/articulos-de-interes/observatorio-de-castilla-la-mancha-sobre-el-brexit/",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "El Observatorio de la Discapacidad de Rivas Vaciamadrid nació en el 2009 como una iniciativa conjunta entre la corporación local y las diferentes entidades y asociaciones del municipio que trabajan con, para y por las personas con discapacidad y dependencia. Entre sus objetivos se encuentran: Promover la plena participación de las personas con discapacidades en la vida ciudadana. Velar y colaborar en el desarrollo de las políticas y actuaciones en materia de protección y promoción de la calidad de vida de las personas con discapacidades, por parte de todas las Administraciones Públicas. Hacer visible en el municipio las necesidades y las capacidades de las personas con algún tipo de discapacidad. Su principal función se centra son conocer la realidad de la situación de estas personas, crear espacios de participación social en los que se recojan las propuestas e inquietudes, y se promuevan iniciativas que atiendan las necesidades planteadas.",
@@ -3706,7 +3802,11 @@
     "parents": ["Ayuntamiento de Rivas-Vaciamadrid"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.rivasciudad.es/organos-de-participacion-ciudadana/foros-y-observatorios-locales/observatorio-municipal-de-personas-con-discapacidades/"
+    "website": "https://www.rivasciudad.es/organos-de-participacion-ciudadana/foros-y-observatorios-locales/observatorio-municipal-de-personas-con-discapacidades/",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    }
   },
   {
     "description": "El Observatorio de la Ciudad, instrumento de evaluación de la gestión municipal y de difusión e información de sus resultados a la ciudadanía, tiene como finalidad impulsar de forma institucional la evaluación de la gestión municipal, la rendición de cuentas y la efectividad de los principios de transparencia y participación, teniendo en cuenta especialmente la percepción que tiene la ciudadanía de la calidad de los servicios municipales.",
@@ -3729,7 +3829,11 @@
       "Junta de Castilla-La Mancha"
     ],
     "scope": "castilla_la_mancha",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Elaboración de propuestas para la mejora de la convivencia.",
@@ -3742,7 +3846,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://www.educa.jccm.es/educa-jccm/cm/educa_jccm/tkContent?idContent=62664&locale=en_UK&textOnly=false"
+    "website": "https://www.educa.jccm.es/educa-jccm/cm/educa_jccm/tkContent?idContent=62664&locale=en_UK&textOnly=false",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Desde la Oficina Verde de la Universidad de Burgos (UbuVerde), y con la colaboración de Sodebur se ha creado un Observatorio por la Repoblacción Rural de castilla y León, cuyo objetivo es informar de la actualidad, analizar y determinar la evolución de la realidad demográfica en el medio rural de Castilla y león. Además, sensibilizar a la población y hacer ver la realidad de esta situación.\n\n- Oficina Verde de la Universidad de Burgos (UbuVerde)\r\n- Sodebur (Sociedad para el desarrollo de la povincia de Burgos)",
@@ -3757,7 +3865,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.ubu.es/ubuverde/repoblacion-rural/observatorio-por-la-repoblacion-rural"
+    "website": "https://www.ubu.es/ubuverde/repoblacion-rural/observatorio-por-la-repoblacion-rural",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "email": "smartcatalonia@gencat.cat",
@@ -3802,7 +3914,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://empleoyformacion.castillalamancha.es/observatorio"
+    "website": "https://empleoyformacion.castillalamancha.es/observatorio",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Mantenimiento de un sistema de indicadores que permita el seguimiento de la evolución del consumo de drogas en Castilla-La Mancha.",
@@ -3825,7 +3941,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://sanidad.castillalamancha.es/ciudadanos/observatorio-de-drogodependencias-clm/que-es-el-od"
+    "website": "https://sanidad.castillalamancha.es/ciudadanos/observatorio-de-drogodependencias-clm/que-es-el-od",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "L'Observatori-Centre d'Estudis és un instrument de suport a la presa de decisions per tal que aquestes adquireixin un caràcter més estratègic. També és un element de suport per als tècnics que treballen en els diversos àmbits locals. L’existència d’un Centre d’Estudis permet l' anàlisi prèvia a l’hora de planificar o dissenyar actuacions facilitant que es pugui respondre millor a les necessitats reals del territori o les actuacions a desenvolupar des del propi Consell Comarcal. L’Observatori actua com a banc de dades, per tal d’aglutinar i guardar la informació relativa als municipis així com també fer difusió o recollir dades d’àmbits superiors amb incidència en l’àmbit local.\n\nCarta de Serveis Observatori-Centre d'Estudis => [ENLACE](https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/carta-de-serveis/)\n\nObservatori-centre d’estudis del Vallès Oriental ( otro enlace )\n\nhttps://www.vallesoriental.cat/2028-el-consell/guia-de-serveis-i-cartes-de-servei/desenvolupament-socioeconomic/observatori-centre-destudis-del-valles-oriental.html",
@@ -3904,7 +4024,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.observatoriotransformacion.com"
+    "website": "https://www.observatoriotransformacion.com",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "docs": [
@@ -3958,7 +4082,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://observatoriolgtbiclm.com"
+    "website": "https://observatoriolgtbiclm.com",
+    "coordinates": {
+      "lat": 40.7399963,
+      "lon": -2.50593
+    }
   },
   {
     "docs": [
@@ -4053,7 +4181,11 @@
         "name": "Informes Anuales de Transformación Urbana (todavía no publicado)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3397709,
+      "lon": -5.8408396
+    }
   },
   {
     "description": "Observa los precios de venta al público y trata de identificar posibles subidas injustificadas de precios.",
@@ -4532,7 +4664,11 @@
       "Generalitat Valenciana",
       "Ministerio de Trabajo y Economía Social"
     ],
-    "website": "https://observatorimarinaalta.org"
+    "website": "https://observatorimarinaalta.org",
+    "coordinates": {
+      "lat": 38.7567857,
+      "lon": -0.0044809
+    }
   },
   {
     "name": "Observatorio de la Formación en el Transporte por Carretera",
@@ -4621,7 +4757,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://mediambient.gva.es/es/web/agua/novedades/-/asset_publisher/cYq5fnvdHYwT/content/observatorio-ciudadano-del-agua-de-la-comunitat-valenciana"
+    "website": "https://mediambient.gva.es/es/web/agua/novedades/-/asset_publisher/cYq5fnvdHYwT/content/observatorio-ciudadano-del-agua-de-la-comunitat-valenciana",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5257,7 +5397,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.caib.es/sites/observatorideltreball/es/portada-10648/"
+    "website": "https://www.caib.es/sites/observatorideltreball/es/portada-10648/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Sus actividades incluyen la reunión periódica de sus miembros sobre temas particulares relativos al desarrollo de la industria en España, la realización de estudios de caso y conferencias de expertos, así como la elaboración de un informe anual sobre el estado de las finanzas islámicas en España.",
@@ -5481,7 +5625,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.oag-fundacion.org/"
+    "website": "https://www.oag-fundacion.org/",
+    "coordinates": {
+      "lat": 28.4857715,
+      "lon": -16.3159422
+    }
   },
   {
     "from_date": "2011",
@@ -5920,7 +6068,11 @@
     "scope": "extremadura",
     "parents": ["Junta de Extremadura"],
     "is_active": "Si",
-    "description": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura es un servicio público de información y análisis del mercado de trabajo en Extremadura, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura es un servicio público de información y análisis del mercado de trabajo en Extremadura, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Resultados del Servicio Murciano de Salud",
@@ -6298,7 +6450,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Se ofrece un formulario de contacto general.",
-    "from_date": "2018 (Copyright del sitio web)"
+    "from_date": "2018 (Copyright del sitio web)",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatori del Patrimoni Natural i la Biodiversitat",
@@ -6690,7 +6846,11 @@
     "scope": "local",
     "type": "publico",
     "is_active": "No",
-    "from_date": "2023-01-11 (Anunciado/En creación)"
+    "from_date": "2023-01-11 (Anunciado/En creación)",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    }
   },
   {
     "name": "Observatorio del Impacto Social de los Algoritmos (OBISAL)",
@@ -6755,7 +6915,11 @@
     "parents": ["Cabildo de Gran Canaria", "Turismo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://observatorioturisticograncanaria.com/"
+    "website": "https://observatorioturisticograncanaria.com/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Euskal Herriko Giza Eskubideen Behatokia (GEBEHATOKIA)",
@@ -6795,7 +6959,11 @@
     "parents": ["Gobierno Vasco", "Universidad del País Vasco (UPV/EHU)"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://eeb-ove.eus/observatorio/"
+    "website": "https://eeb-ove.eus/observatorio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Behatokia (Gizarte Aurreikuspen Osagarria)",
@@ -6885,7 +7053,11 @@
     "description": "Observatorio para el seguimiento/impulso de la accesibilidad en Gran Canaria. <a href=\"https://www.grancanariaaccesible.info/observatorio/\">Sitio web</a>.",
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.grancanariaaccesible.info/observatorio/"
+    "website": "https://www.grancanariaaccesible.info/observatorio/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio del Comercio de Gran Canaria",
@@ -6893,7 +7065,11 @@
     "parents": ["Cámara de Comercio de Gran Canaria"],
     "scope": "canarias",
     "type": "mixto",
-    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/"
+    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de Prospectiva para la Gobernanza Insular",


### PR DESCRIPTION
## Resumen

Se añade el campo opcional "coordinates" (lat/lon, WGS84) a los observatorios que ya tenían "location" explícita, para poder representarlos en un mapa.

## Observatorios con coordenadas

- Observatori Municipal de l'Habitatge d'Alcoi
- Observatorio da Lingua Galega
- Observatorio de Empleo y Formación del Servicio Cántabro de Empleo
- Observatorio Urbano de A Coruña
- Observatorio Municipal de Igualdade e Diversidade
- Observatorio Turístico de A Coruña
- Observatorio Urbano de Alcalá de Henares
- Observatorio de Violencia de Género de Alcalá
- Observatorio Sociodemográfico del Ayuntamiento de Alcalá de Henares
- Observatorio Alcalá en Cifras
- Observatorio Tributario Andaluz
- Observatorio Municipal de Violencia contra las Mujeres (Ayuntamiento de Madrid)
- Observatorio de la Ciudad (Ayuntamiento de Madrid)
- Observatorio de la Ciudad de Móstoles (Móstoles Desarrollo)
- Observatorio de Gobierno Abierto de Getafe (Observatorio Estadístico Municipal)
- Observatorio de Ciudad de Rivas Vaciamadrid (Observatorio Urbano RIVAS 2030)
- Observatorio de la calidad del aire (Terrassa)
- Observatori de l'aigua (Terrassa)
- Observatorio Urbano de la Agenda Urbana de Valverde de Burguillos
- Observatorio Local de Sostenibilidad de Albacete (OLSA)
- Indicadores de Administración Digital (Ayuntamiento de Madrid)
- Observatorio del Ruido (Algete)
- Observatorio de la Calidad del Aire (Algete)

## Pruebas

- jq -e . httpdocs/observatories.json
- npx prettier --check "httpdocs/**/*.{js,json,css}"
