### PR TITLE
[feature] Añadir mapa interactivo de observatorios

### DIFF
--- a/httpdocs/index.html
+++ b/httpdocs/index.html
@@ -28,6 +28,10 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css"
+    />
     <link rel="stylesheet" href="/stylesheets/typography.css" />
     <link rel="stylesheet" href="/stylesheets/observatoriospublicos.css" />
     <link rel="stylesheet" href="/stylesheets/searchbar.css" />
@@ -35,6 +39,10 @@
     <link rel="icon" type="image/svg+xml" href="/assets/icon.svg" />
     <link rel="apple-touch-icon" href="/assets/icon.png" />
 
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"
+    ></script>
     <script type="module" src="/modules/observatoriospublicos.js"></script>
 
     <meta name="twitter:card" content="summary_large_image" />
@@ -3101,6 +3109,9 @@
           público-privados de España. De momento hemos identificado
           <mark data-tooltip="Y los que quedan…">estos</mark>.
         </p>
+
+        <div id="observatories-map" aria-label="Mapa de observatorios"></div>
+        <small id="observatories-map-stats"></small>
 
         <x-catalog></x-catalog>
 

--- a/httpdocs/modules/map.js
+++ b/httpdocs/modules/map.js
@@ -1,5 +1,8 @@
 let map = null
+let pointsLayer = null
+let clusteredPoints = null
 
+const clusterGridSize = 64 // px
 const maxPopupItems = 15
 
 function escapeHtml(value) {
@@ -13,6 +16,19 @@ function escapeHtml(value) {
 
 function escapeAttr(value) {
   return escapeHtml(value).replaceAll('`', '&#96;')
+}
+
+function createCountIcon(L, count, variant) {
+  const safeCount = Number.isFinite(count) ? Math.max(1, Math.round(count)) : 1
+  const size = Math.round(22 + Math.min(18, Math.log2(safeCount) * 6))
+
+  return L.divIcon({
+    className: 'map-pin-wrapper',
+    html: `<div class="map-pin ${variant === 'cluster' ? 'map-pin--cluster' : ''}" style="width:${size}px;height:${size}px"><span>${safeCount}</span></div>`,
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+    popupAnchor: [0, -size / 2],
+  })
 }
 
 function buildPopup(observatories) {
@@ -91,6 +107,68 @@ function groupByCoordinates(observatories) {
   }
 }
 
+function clusterByZoom(map, L, points) {
+  const zoom = map.getZoom()
+  const buckets = new Map()
+
+  for (const point of points) {
+    const projected = map.project([point.lat, point.lon], zoom)
+    const x = Math.floor(projected.x / clusterGridSize)
+    const y = Math.floor(projected.y / clusterGridSize)
+    const key = `${x},${y}`
+
+    const bucket = buckets.get(key) || {
+      points: 0,
+      count: 0,
+      sumX: 0,
+      sumY: 0,
+      observatories: [],
+    }
+
+    bucket.points += 1
+    bucket.count += point.count
+    bucket.sumX += projected.x * point.count
+    bucket.sumY += projected.y * point.count
+    bucket.observatories.push(...point.observatories)
+
+    buckets.set(key, bucket)
+  }
+
+  return [...buckets.values()].map((bucket) => {
+    const centerPoint = L.point(
+      bucket.sumX / bucket.count,
+      bucket.sumY / bucket.count,
+    )
+    const center = map.unproject(centerPoint, zoom)
+
+    return {
+      center,
+      count: bucket.count,
+      isCluster: bucket.points > 1,
+      observatories: bucket.observatories,
+    }
+  })
+}
+
+function renderPoints({ L }) {
+  if (!map || !pointsLayer || !clusteredPoints) return
+
+  pointsLayer.clearLayers()
+
+  const items = clusterByZoom(map, L, clusteredPoints)
+
+  for (const item of items) {
+    const icon = createCountIcon(
+      L,
+      item.count,
+      item.isCluster ? 'cluster' : 'point',
+    )
+    const marker = L.marker(item.center, { icon })
+    marker.bindPopup(buildPopup(item.observatories))
+    marker.addTo(pointsLayer)
+  }
+}
+
 export function initMap(observatories) {
   if (map) return
 
@@ -125,26 +203,23 @@ export function initMap(observatories) {
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
   }).addTo(map)
 
-  const layer = L.featureGroup().addTo(map)
+  clusteredPoints = groups.map((group) => ({
+    lat: group.lat,
+    lon: group.lon,
+    count: group.observatories.length,
+    observatories: group.observatories,
+  }))
 
-  for (const group of groups) {
-    const count = group.observatories.length
-    const radius = 4 + Math.min(8, Math.log2(count) * 2)
+  pointsLayer = L.layerGroup().addTo(map)
+  renderPoints({ L })
 
-    const marker = L.circleMarker([group.lat, group.lon], {
-      radius,
-      weight: 1,
-      color: '#111',
-      fillColor: '#111',
-      fillOpacity: 0.65,
-    })
+  map.on('zoomend', () => renderPoints({ L }))
 
-    marker.bindPopup(buildPopup(group.observatories))
-    marker.addTo(layer)
-  }
-
-  if (layer.getLayers().length) {
-    map.fitBounds(layer.getBounds(), { padding: [24, 24] })
+  if (clusteredPoints.length) {
+    map.fitBounds(
+      L.latLngBounds(clusteredPoints.map(({ lat, lon }) => [lat, lon])),
+      { padding: [24, 24] },
+    )
   } else {
     map.setView([40.416782, -3.703507], 5)
   }

--- a/httpdocs/modules/map.js
+++ b/httpdocs/modules/map.js
@@ -194,8 +194,22 @@ export function initMap(observatories) {
   const { L } = window
 
   map = L.map(container, {
-    scrollWheelZoom: false,
+    scrollWheelZoom: true,
+    touchZoom: true,
   })
+
+  // Permite zoom por rueda/pinch solo cuando el usuario lo hace de forma intencional
+  // (Ctrl/Cmd + scroll o pinch en trackpad, que suele marcar ctrlKey).
+  // Asi evitamos que el mapa "robe" el scroll normal de la pagina.
+  container.addEventListener(
+    'wheel',
+    (event) => {
+      if (!(event.ctrlKey || event.metaKey)) {
+        event.stopImmediatePropagation()
+      }
+    },
+    { capture: true },
+  )
 
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,

--- a/httpdocs/modules/map.js
+++ b/httpdocs/modules/map.js
@@ -1,0 +1,151 @@
+let map = null
+
+const maxPopupItems = 15
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replaceAll('`', '&#96;')
+}
+
+function buildPopup(observatories) {
+  if (!observatories.length) return ''
+
+  if (observatories.length === 1) {
+    const o = observatories[0]
+    const name = escapeHtml(o.name)
+    const location = o.location ? escapeHtml(o.location) : null
+    const website = o.website ? escapeAttr(o.website) : null
+
+    return `
+      <div class="map-popup">
+        <strong>${name}</strong>
+        ${location ? `<br /><small>${location}</small>` : ''}
+        ${website ? `<br /><a href="${website}">Sitio web</a>` : ''}
+      </div>
+    `
+  }
+
+  const sorted = observatories
+    .slice()
+    .sort((a, b) => String(a.name).localeCompare(String(b.name), 'es'))
+
+  const list = sorted.slice(0, maxPopupItems)
+  const remaining = sorted.length - list.length
+
+  const itemsHtml = list
+    .map((o) => {
+      const name = escapeHtml(o.name)
+      const website = o.website ? escapeAttr(o.website) : null
+      return `<li>${website ? `<a href="${website}">${name}</a>` : name}</li>`
+    })
+    .join('')
+
+  return `
+    <div class="map-popup">
+      <strong>${observatories.length} observatorios</strong>
+      <ul>${itemsHtml}</ul>
+      ${remaining > 0 ? `<small>… y ${remaining} más.</small>` : ''}
+    </div>
+  `
+}
+
+function getValidCoordinates(observatory) {
+  const coords = observatory.coordinates
+  if (!coords) return null
+
+  const lat = Number(coords.lat)
+  const lon = Number(coords.lon)
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+
+  return { lat, lon }
+}
+
+function groupByCoordinates(observatories) {
+  const groups = new Map()
+  let withCoordinates = 0
+
+  for (const o of observatories) {
+    const coords = getValidCoordinates(o)
+    if (!coords) continue
+
+    withCoordinates += 1
+
+    // Agrupamos por coordenada para evitar marcadores solapados.
+    const key = `${coords.lat.toFixed(6)},${coords.lon.toFixed(6)}`
+    const group = groups.get(key) || { ...coords, observatories: [] }
+    group.observatories.push(o)
+    groups.set(key, group)
+  }
+
+  return {
+    groups: [...groups.values()],
+    withCoordinates,
+  }
+}
+
+export function initMap(observatories) {
+  if (map) return
+
+  const container = document.getElementById('observatories-map')
+  if (!container) return
+
+  const stats = document.getElementById('observatories-map-stats')
+
+  if (!window.L) {
+    if (stats) {
+      stats.textContent = 'No se ha podido cargar el mapa.'
+    }
+    return
+  }
+
+  const { groups, withCoordinates } = groupByCoordinates(observatories)
+  const withoutCoordinates = observatories.length - withCoordinates
+
+  if (stats) {
+    stats.textContent = `${withCoordinates} con coordenadas (${groups.length} puntos) · ${withoutCoordinates} sin coordenadas`
+  }
+
+  const { L } = window
+
+  map = L.map(container, {
+    scrollWheelZoom: false,
+  })
+
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  }).addTo(map)
+
+  const layer = L.featureGroup().addTo(map)
+
+  for (const group of groups) {
+    const count = group.observatories.length
+    const radius = 4 + Math.min(8, Math.log2(count) * 2)
+
+    const marker = L.circleMarker([group.lat, group.lon], {
+      radius,
+      weight: 1,
+      color: '#111',
+      fillColor: '#111',
+      fillOpacity: 0.65,
+    })
+
+    marker.bindPopup(buildPopup(group.observatories))
+    marker.addTo(layer)
+  }
+
+  if (layer.getLayers().length) {
+    map.fitBounds(layer.getBounds(), { padding: [24, 24] })
+  } else {
+    map.setView([40.416782, -3.703507], 5)
+  }
+}

--- a/httpdocs/modules/map.js
+++ b/httpdocs/modules/map.js
@@ -38,13 +38,12 @@ function buildPopup(observatories) {
     const o = observatories[0]
     const name = escapeHtml(o.name)
     const location = o.location ? escapeHtml(o.location) : null
-    const website = o.website ? escapeAttr(o.website) : null
+    const observatoryAttr = o.name ? escapeAttr(o.name) : ''
 
     return `
       <div class="map-popup">
-        <strong>${name}</strong>
+        <strong><a class="map-open-observatory" href="#" data-observatory="${observatoryAttr}">${name}</a></strong>
         ${location ? `<br /><small>${location}</small>` : ''}
-        ${website ? `<br /><a href="${website}">Sitio web</a>` : ''}
       </div>
     `
   }
@@ -59,8 +58,8 @@ function buildPopup(observatories) {
   const itemsHtml = list
     .map((o) => {
       const name = escapeHtml(o.name)
-      const website = o.website ? escapeAttr(o.website) : null
-      return `<li>${website ? `<a href="${website}">${name}</a>` : name}</li>`
+      const observatoryAttr = o.name ? escapeAttr(o.name) : ''
+      return `<li><a class="map-open-observatory" href="#" data-observatory="${observatoryAttr}">${name}</a></li>`
     })
     .join('')
 
@@ -196,6 +195,26 @@ export function initMap(observatories) {
   map = L.map(container, {
     scrollWheelZoom: true,
     touchZoom: true,
+  })
+
+  container.addEventListener('click', (event) => {
+    const target = event.target
+    const link =
+      target instanceof Element
+        ? target.closest('a.map-open-observatory')
+        : null
+    if (!link) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const name = link.dataset.observatory
+    if (!name) return
+
+    if (typeof window.openObservatoryModal === 'function') {
+      window.openObservatoryModal(name)
+      map.closePopup()
+    }
   })
 
   // Permite zoom por rueda/pinch solo cuando el usuario lo hace de forma intencional

--- a/httpdocs/modules/map.js
+++ b/httpdocs/modules/map.js
@@ -66,7 +66,7 @@ function buildPopup(observatories) {
   return `
     <div class="map-popup">
       <strong>${observatories.length} observatorios</strong>
-      <ul>${itemsHtml}</ul>
+      <ul class="map-popup-list">${itemsHtml}</ul>
       ${remaining > 0 ? `<small>… y ${remaining} más.</small>` : ''}
     </div>
   `
@@ -217,17 +217,41 @@ export function initMap(observatories) {
     }
   })
 
-  // Permite zoom por rueda/pinch solo cuando el usuario lo hace de forma intencional
-  // (Ctrl/Cmd + scroll o pinch en trackpad, que suele marcar ctrlKey).
-  // Asi evitamos que el mapa "robe" el scroll normal de la pagina.
+  // Cuando el ratón está sobre el mapa, Leaflet captura la rueda para hacer zoom
+  // y así evitamos que el scroll afecte a la página.
+  // Excepción: si el scroll ocurre dentro de la lista del popup, hacemos scroll
+  // de la lista y evitamos que el evento llegue al mapa o "se escape" a la página.
   container.addEventListener(
     'wheel',
     (event) => {
-      if (!(event.ctrlKey || event.metaKey)) {
+      if (event.ctrlKey || event.metaKey) return
+
+      const target = event.target
+      const list =
+        target instanceof Element ? target.closest('.map-popup-list') : null
+
+      if (list) {
+        // Permitimos scroll dentro de la lista, pero evitamos:
+        // - que el mapa haga zoom
+        // - que el scroll continúe hacia la página al llegar al límite
+        const canScroll = list.scrollHeight > list.clientHeight
+        if (!canScroll) return
+        const isDown = event.deltaY > 0
+        const isUp = event.deltaY < 0
+        const atTop = list.scrollTop <= 0
+        const atBottom =
+          Math.ceil(list.scrollTop + list.clientHeight) >= list.scrollHeight
+
         event.stopImmediatePropagation()
+
+        if (!canScroll || (isUp && atTop) || (isDown && atBottom)) {
+          event.preventDefault()
+        }
+
+        return
       }
     },
-    { capture: true },
+    { capture: true, passive: false },
   )
 
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/httpdocs/modules/observatoriospublicos.js
+++ b/httpdocs/modules/observatoriospublicos.js
@@ -152,4 +152,27 @@ const getScrollbarWidth = () => {
   return scrollbarWidth
 }
 
+// API global mínima para poder abrir el modal desde otros componentes (p.ej. mapa)
+window.openObservatoryModal = (name) => {
+  if (!name || !currentObservatories) return
+
+  const modal = document.getElementById('observatory')
+  if (!modal) return
+
+  const observatory = currentObservatories.find((o) => o.name === name)
+  if (!observatory) return
+
+  // Si ya está abierto, solo actualizamos el contenido (showModal() lanzaría error).
+  if (modal.open) {
+    visibleModal = modal
+    const div = modal.querySelector('#observatory-content')
+    const h3 = modal.querySelector('#observatory-title')
+    div.innerHTML = createObservatoryDetailsComponent(observatory)
+    h3.innerText = observatory.name
+    return
+  }
+
+  openModal(modal, { currentTarget: { dataset: { observatory: name } } })
+}
+
 main()

--- a/httpdocs/modules/observatoriospublicos.js
+++ b/httpdocs/modules/observatoriospublicos.js
@@ -3,6 +3,7 @@ import {
   createObservatoryDetailsComponent,
   createObservatoryCardComponent,
 } from './observatorioContent.js'
+import { initMap } from './map.js'
 import { initSearchBar } from './searchbar.js'
 
 // Ventana modal
@@ -70,6 +71,9 @@ async function main() {
   // Contador total
   const count = document.querySelector('mark')
   count.innerHTML = observatories.length.toString()
+
+  // Mapa
+  initMap(observatories)
 
   // Se actualizan los observatorios
   updateObservatories(observatories)

--- a/httpdocs/modules/observatoriospublicos.js
+++ b/httpdocs/modules/observatoriospublicos.js
@@ -11,6 +11,7 @@ let visibleModal = null
 
 // Observatorios en ventana
 let currentObservatories = null
+let allObservatories = null
 
 /**
  * Genera la lista de observatorios en el HTML
@@ -52,6 +53,7 @@ export function updateObservatories(thisObservatories) {
 
 async function main() {
   const observatories = await fetch('/observatories.json').then((x) => x.json())
+  allObservatories = observatories.slice()
 
   const errors = [
     ...observatories
@@ -125,10 +127,12 @@ const openModal = (modal, event) => {
   const div = modal.querySelector('#observatory-content')
   const h3 = modal.querySelector('#observatory-title')
 
-  const observatory = currentObservatories.find(
-    ({ name }) => name === event.currentTarget.dataset.observatory,
-  )
-  const json = JSON.stringify(observatory, null, 2)
+  const observatoryName = event.currentTarget.dataset.observatory
+  const observatory =
+    (allObservatories || []).find(({ name }) => name === observatoryName) ||
+    (currentObservatories || []).find(({ name }) => name === observatoryName)
+  if (!observatory) return
+
   div.innerHTML = createObservatoryDetailsComponent(observatory)
   h3.innerText = observatory.name
 
@@ -154,12 +158,14 @@ const getScrollbarWidth = () => {
 
 // API global mínima para poder abrir el modal desde otros componentes (p.ej. mapa)
 window.openObservatoryModal = (name) => {
-  if (!name || !currentObservatories) return
+  if (!name) return
 
   const modal = document.getElementById('observatory')
   if (!modal) return
 
-  const observatory = currentObservatories.find((o) => o.name === name)
+  const observatory =
+    (allObservatories || []).find((o) => o.name === name) ||
+    (currentObservatories || []).find((o) => o.name === name)
   if (!observatory) return
 
   // Si ya está abierto, solo actualizamos el contenido (showModal() lanzaría error).

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -84,6 +84,10 @@
     ],
     "from_date": "2020-07-22",
     "location": "Alcoy",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    },
     "name": "Observatori Municipal de l'Habitatge d'Alcoi",
     "scope": "municipal",
     "type": "publico",
@@ -1353,6 +1357,10 @@
     "is_active": "Si",
     "email": "info@observatoriodalinguagalega.org",
     "location": "Rúa de San Roque, n.º 2 15704 Santiago de Compostela",
+    "coordinates": {
+      "lat": 42.8832409,
+      "lon": -8.5416849
+    },
     "phone": "+34 881 996 302",
     "docs": [
       {
@@ -1492,7 +1500,11 @@
     "website": "https://empleacantabria.es/",
     "is_active": "Si",
     "email": "empleacantabria@cantabria.es",
-    "location": "Paseo General Dávila 87, 39006 Santander"
+    "location": "Paseo General Dávila 87, 39006 Santander",
+    "coordinates": {
+      "lat": 43.4665639,
+      "lon": -3.8145583
+    }
   },
   {
     "name": "Observatorio Español de la Economía Social y del Trabajo Autónomo",
@@ -1790,6 +1802,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Urbano de A Coruña",
     "parents": ["Concello de A Coruña"],
     "scope": "municipal",
@@ -1797,6 +1813,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Municipal de Igualdade e Diversidade",
     "parents": ["Concello de A Coruña"],
     "scope": "municipal",
@@ -1820,6 +1840,10 @@
   },
   {
     "location": "A Coruña",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    },
     "name": "Observatorio Turístico de A Coruña",
     "parents": ["Concello de A Coruña", "Universidade da Coruña"],
     "scope": "municipal",
@@ -1945,6 +1969,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Urbano de Alcalá de Henares",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1953,6 +1981,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio de Violencia de Género de Alcalá",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1979,6 +2011,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Sociodemográfico del Ayuntamiento de Alcalá de Henares",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -1987,6 +2023,10 @@
   },
   {
     "location": "Alcalá de Henares",
+    "coordinates": {
+      "lat": 40.481954,
+      "lon": -3.363981
+    },
     "name": "Observatorio Alcalá en Cifras",
     "parents": ["Ayuntamiento de Alcalá de Henares"],
     "scope": "municipal",
@@ -2648,6 +2688,10 @@
     ],
     "email": "ota@malaga.eu",
     "location": "Málaga",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    },
     "name": "Observatorio Tributario Andaluz",
     "parents": [
       "Ayuntamiento de Málaga",
@@ -5942,6 +5986,10 @@
     "from_date": "2022-07-29",
     "is_active": "Si",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "name": "Observatorio Municipal de Violencia contra las Mujeres (Ayuntamiento de Madrid)",
     "parents": [
       "Ayuntamiento de Madrid",
@@ -5966,6 +6014,10 @@
     "from_date": "2019-03-30",
     "is_active": "Si",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "name": "Observatorio de la Ciudad (Ayuntamiento de Madrid)",
     "parents": [
       "Ayuntamiento de Madrid",
@@ -5987,6 +6039,10 @@
     "from_date": "2017",
     "is_active": "Si",
     "location": "Móstoles",
+    "coordinates": {
+      "lat": 40.3238525,
+      "lon": -3.8649214
+    },
     "name": "Observatorio de la Ciudad de Móstoles (Móstoles Desarrollo)",
     "parents": ["Ayuntamiento de Móstoles", "Móstoles Desarrollo S.A."],
     "scope": "municipal",
@@ -5998,6 +6054,10 @@
     "from_date": "2018-04-18",
     "is_active": "Si",
     "location": "Getafe",
+    "coordinates": {
+      "lat": 40.3070639,
+      "lon": -3.7331808
+    },
     "name": "Observatorio de Gobierno Abierto de Getafe (Observatorio Estadístico Municipal)",
     "parents": [
       "Ayuntamiento de Getafe",
@@ -6019,6 +6079,10 @@
     "from_date": "2015",
     "is_active": "Si",
     "location": "Rivas Vaciamadrid",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    },
     "name": "Observatorio de Ciudad de Rivas Vaciamadrid (Observatorio Urbano RIVAS 2030)",
     "parents": [
       "Ayuntamiento de Rivas Vaciamadrid",
@@ -6748,6 +6812,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Terrassa (Barcelona)",
+    "coordinates": {
+      "lat": 41.5629623,
+      "lon": 2.0100492
+    },
     "website": "https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire"
   },
   {
@@ -6757,6 +6825,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Terrassa (Barcelona)",
+    "coordinates": {
+      "lat": 41.5629623,
+      "lon": 2.0100492
+    },
     "website": "https://www.terrassa.cat/recursos-educatius"
   },
   {
@@ -6865,6 +6937,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Valverde de Burguillos (Badajoz)",
+    "coordinates": {
+      "lat": 38.3273746,
+      "lon": -6.5363287
+    },
     "website": "https://agendaurbanavalverdeburguillos2030.badajoz.es/"
   },
   {
@@ -6881,6 +6957,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Albacete",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    },
     "website": "https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj"
   },
   {
@@ -6902,6 +6982,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Madrid",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    },
     "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default"
   },
   {
@@ -6911,6 +6995,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Algete (Madrid)",
+    "coordinates": {
+      "lat": 40.5961297,
+      "lon": -3.4974479
+    },
     "website": "https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624"
   },
   {
@@ -6920,6 +7008,10 @@
     "scope": "municipal",
     "type": "publico",
     "location": "Algete (Madrid)",
+    "coordinates": {
+      "lat": 40.5961297,
+      "lon": -3.4974479
+    },
     "website": "https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item"
   }
 ]

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -8893,5 +8893,131 @@
       "lon": -3.4974479
     },
     "website": "https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item"
+  },
+  {
+    "name": "Observatorio Insular de Turismo de Fuerteventura (OITF)",
+    "location": "Puerto del Rosario, Fuerteventura (Las Palmas)",
+    "description": "Plataforma/observatorio turístico del Cabildo (Patronato de Turismo) para monitorizar tendencias y comportamiento de visitantes. <a href=\"https://www.cabildofuer.es/cabildo/el-patronato-muestra-al-sector-y-ayuntamientos-el-funcionamiento-del-observatorio-insular-de-turismo/\">Fuente</a>.",
+    "parents": [
+      "Cabildo de Fuerteventura",
+      "Patronato de Turismo de Fuerteventura"
+    ],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://www.cabildofuer.es/cabildo/el-patronato-muestra-al-sector-y-ayuntamientos-el-funcionamiento-del-observatorio-insular-de-turismo/",
+    "coordinates": {
+      "lat": 28.4985221,
+      "lon": -13.8607685
+    }
+  },
+  {
+    "name": "Observatori / Observatorio contra la LGTBI-fòbia de Nules",
+    "location": "Nules (Castellón)",
+    "description": "Observatorio municipal contra la LGTBI-fobia promovido por el Ayuntamiento de Nules. <a href=\"https://nules.org/es/2024/04/15/nules-crea-el-primer-observatori-contra-la-lgtbi-fobia/\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Nules"],
+    "scope": "municipal",
+    "type": "publico",
+    "website": "https://nules.org/es/2024/04/15/nules-crea-el-primer-observatori-contra-la-lgtbi-fobia/",
+    "coordinates": {
+      "lat": 39.8533759,
+      "lon": -0.1548132
+    }
+  },
+  {
+    "name": "Observatorio Meteorológico de Igueldo",
+    "location": "Monte Igueldo, Donostia/San Sebastián (Gipuzkoa)",
+    "description": "Reapertura y puesta en marcha del observatorio/estación meteorológica de Igeldo (Igueldo) en Donostia/San Sebastián. <a href=\"https://www.aemet.es/es/noticias/2021/12/reapertura_igueldo\">Fuente</a>.",
+    "parents": ["Agencia Estatal de Meteorología (AEMET)"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.aemet.es/es/noticias/2021/12/reapertura_igueldo",
+    "coordinates": {
+      "lat": 43.3063889,
+      "lon": -2.0411111
+    }
+  },
+  {
+    "name": "Observatorio de Indicadores de la Agenda Urbana 2030 de Vitoria-Gasteiz",
+    "location": "Vitoria-Gasteiz (Álava)",
+    "description": "Observatorio/plataforma de indicadores de la Agenda Urbana 2030 de Vitoria-Gasteiz, con mejoras adicionales contratadas en 2025 (expediente 2025/CO_SSER/0076). <a href=\"https://www.euskadi.eus/anuncio_contratacion/mejoras-adicionales-para-el-desarrollo-del-observatorio-de-indicadores-de-la-agenda-urbana-2030-en-la-ciudad-de-vitoria-gasteiz/web01-s2ing/es/\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Vitoria-Gasteiz"],
+    "scope": "municipal",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/anuncio_contratacion/mejoras-adicionales-para-el-desarrollo-del-observatorio-de-indicadores-de-la-agenda-urbana-2030-en-la-ciudad-de-vitoria-gasteiz/web01-s2ing/es/",
+    "coordinates": {
+      "lat": 42.8468097,
+      "lon": -2.6723289
+    }
+  },
+  {
+    "name": "Observatorio de Sostenibilidad (Reserva de la Biosfera La Palma)",
+    "location": "Santa Cruz de La Palma (Santa Cruz de Tenerife)",
+    "description": "Observatorio de sostenibilidad de la Fundación Canaria Reserva Mundial de la Biosfera La Palma, orientado a la publicación de indicadores relevantes de la isla. <a href=\"https://lapalmabiosfera.es/la-fundacion-canaria-reserva-mundial-biosfera/observatorio-de-sostenibilidad/\">Fuente</a>.",
+    "parents": ["Fundación Canaria Reserva Mundial de la Biosfera La Palma"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://lapalmabiosfera.es/la-fundacion-canaria-reserva-mundial-biosfera/observatorio-de-sostenibilidad/",
+    "coordinates": {
+      "lat": 28.6832581,
+      "lon": -17.7661801
+    }
+  },
+  {
+    "name": "Observatorio de Empleo (Ayuntamiento de Cartagena)",
+    "location": "Cartagena (Región de Murcia)",
+    "description": "Observatorio municipal de empleo dentro del portal \"Cartagena en cifras\". <a href=\"https://www.adlecartagena.es/empleo/observatorio-municipal-de-empleo/\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Cartagena"],
+    "scope": "municipal",
+    "type": "publico",
+    "website": "https://www.adlecartagena.es/empleo/observatorio-municipal-de-empleo/",
+    "coordinates": {
+      "lat": 37.6025445,
+      "lon": -0.9829459
+    }
+  },
+  {
+    "name": "Observatorio Turístico del Baix Empordà",
+    "location": "La Bisbal d'Empordà (Girona)",
+    "description": "Observatorio turístico comarcal del Baix Empordà, impulsado por el Consell Comarcal (con asesoramiento universitario). <a href=\"https://observatoriemporda.com/\">Fuente</a>.",
+    "parents": [
+      "Consell Comarcal del Baix Empordà",
+      "Universitat Autònoma de Barcelona (UAB)"
+    ],
+    "scope": "cataluna",
+    "type": "publico",
+    "website": "https://observatoriemporda.com/",
+    "coordinates": {
+      "lat": 41.958629,
+      "lon": 3.0392549
+    }
+  },
+  {
+    "name": "Observatorio Astronómico Hispano-Alemán de Calar Alto (CAHA)",
+    "location": "Sierra de los Filabres (Almería)",
+    "description": "Infraestructura científica (ICTS) de observación astronómica en Calar Alto. <a href=\"https://www.caha.es/\">Sitio web</a>. <a href=\"https://www.ciencia.gob.es/AreasTematicas/CienciaTecnologiaEInnovacion/ICTS/MapaICTS/Infraestructuras/observatorio-astronomico-hispano-aleman-de-calar-alto.html\">Referencia ICTS</a>.",
+    "parents": [
+      "Junta de Andalucía",
+      "Instituto de Astrofísica de Andalucía (IAA-CSIC)"
+    ],
+    "scope": "andalucia",
+    "type": "publico",
+    "website": "https://www.caha.es/",
+    "coordinates": {
+      "lat": 37.2236111,
+      "lon": -2.5461111
+    }
+  },
+  {
+    "name": "Observatorio Astrofísico de Javalambre (OAJ)",
+    "location": "Pico del Buitre, Sierra de Javalambre (Teruel)",
+    "description": "Infraestructura científica (ICTS) del Centro de Estudios de Física del Cosmos de Aragón (CEFCA). <a href=\"https://oaj.cefca.es/\">Sitio web</a>. <a href=\"https://www.ciencia.gob.es/AreasTematicas/CienciaTecnologiaEInnovacion/ICTS/MapaICTS/Infraestructuras/observatorio-astrofisico-de-javalambre.html\">Referencia ICTS</a>. <a href=\"https://www.cefca.es/cefca_en.php?id=12\">Coordenadas (CEFCA)</a>.",
+    "parents": ["Centro de Estudios de Física del Cosmos de Aragón (CEFCA)"],
+    "scope": "aragon",
+    "type": "publico",
+    "website": "https://oaj.cefca.es/",
+    "coordinates": {
+      "lat": 40.0418278,
+      "lon": -1.0162722
+    }
   }
 ]

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -6970,7 +6970,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2007"
+    "from_date": "2007",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio de Igualdad de la Región de Murcia",
@@ -6991,7 +6995,11 @@
     "website": "https://www.carm.es/web/pagina?IDCONTENIDO=5137&IDTIPO=11&RASTRO=c771$m5828",
     "scope": "region_de_murcia",
     "type": "publico",
-    "from_date": "2003"
+    "from_date": "2003",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio de la Familia de la Región de Murcia",
@@ -7333,7 +7341,11 @@
     ],
     "is_active": "Sí",
     "email": "observatorio@basquetour.eus",
-    "from_date": "2011"
+    "from_date": "2011",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio del sistema de salud de Castilla y León",
@@ -7371,7 +7383,11 @@
     ],
     "is_active": "Sí",
     "email": "info@observatorinatura.cat (general), m.josa@creaf.uab.cat (comunicación)",
-    "from_date": "2023"
+    "from_date": "2023",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio Turístico de la Comunidad de Madrid",
@@ -7406,7 +7422,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2021"
+    "from_date": "2021",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "name": "Observatorio de Enfermedades Raras de la Comunidad de Madrid",
@@ -7416,7 +7436,11 @@
     "type": "publico",
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2025-05-23"
+    "from_date": "2025-05-23",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "name": "Observatori Valencià de Joventut (OVJ)",
@@ -7462,7 +7486,11 @@
       }
     ],
     "is_active": "Sí",
-    "email": "simbiosindustrialcv.ivace@gva.es"
+    "email": "simbiosindustrialcv.ivace@gva.es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio del Sistema Público Valenciano de Servicios Sociales",
@@ -7481,7 +7509,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2023-05-11 (Sesión constituyente)"
+    "from_date": "2023-05-11 (Sesión constituyente)",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio responsabilidad social empresarial  Galicia",
@@ -7863,7 +7895,11 @@
     "parents": ["Diputación de Albacete"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://observatoriosostenibilidad.dipualba.es/"
+    "website": "https://observatoriosostenibilidad.dipualba.es/",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    }
   },
   {
     "name": "Observatorio de la Agenda Rural Sostenible de la provincia de Segovia",
@@ -7907,7 +7943,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Jokoaren Euskal Behatokia",
@@ -7915,7 +7955,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/"
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Turismoaren Euskal Behatokia",
@@ -7923,7 +7967,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/"
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Banda Zabal Ultralasterraren Euskal Behatokia",
@@ -7931,7 +7979,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu"
+    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Euskal Ekintzailetzaren Behatokia (Observatorio Vasco del Emprendimiento)",
@@ -7951,7 +8003,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/"
+    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de la calidad del aire (Terrassa)",
@@ -7984,7 +8040,11 @@
     "description": "Referencia municipal a un observatorio ambiental Litoral-Besòs como recurso externo sobre calidad del aire. <a href=\"https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire\">Enlace</a>.",
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire"
+    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio Valenciano de Salud",
@@ -7992,7 +8052,11 @@
     "parents": ["Generalitat Valenciana"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud"
+    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Euskadiko Osasun Behatokia",
@@ -8000,7 +8064,11 @@
     "parents": ["Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/"
+    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Gallego de Salud Pública",
@@ -8008,14 +8076,22 @@
     "parents": ["Xunta de Galicia", "Consellería de Sanidade", "SERGAS"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/"
+    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Metropolitano de Transporte de Granada",
     "description": "Anunciado en septiembre de 2025 como observatorio metropolitano de transporte/movilidad sostenible. <a href=\"https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html\">Fuente</a>.",
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html"
+    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de la Movilidad Metropolitana del CTAZ-USJ",
@@ -8026,7 +8102,11 @@
     ],
     "scope": "aragon",
     "type": "mixto",
-    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/"
+    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio para la Accesibilidad de Gran Canaria",
@@ -8096,7 +8176,11 @@
     "parents": ["Diputación de Castellón"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59"
+    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59",
+    "coordinates": {
+      "lat": 40.2518568,
+      "lon": -0.0615052
+    }
   },
   {
     "name": "Observatorio Urbano de la Agenda Urbana de Valverde de Burguillos",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -3167,7 +3167,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/medioambiente/organos/observatorio-canario-del-cambio-climatico/"
+    "website": "https://www.gobiernodecanarias.org/medioambiente/organos/observatorio-canario-del-cambio-climatico/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "El Observatorio de la Criminalidad Organizada Transnacional (OCOT) es un espacio interdisciplinario, crítico, reflexivo y de formación-acción que congrega una amplia red internacional de profesores e investigadores dedicados al estudio de la criminalidad organizada de modo pormenorizado. Es, además, un ambiente de alto nivel académico-científico y creciente reconocimiento nacional e internacional en la materia, especialmente dado su carácter pionero en el modo con el que aborda la temática estudiada, la calificada producción científica que impulsa, los distintos proyectos de investigación con financiación nacional que le dan cuerpo y la responsabilidad social que caracterizan sus acciones y reflexiones.",
@@ -3216,7 +3220,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www3.gobiernodecanarias.org/sanidad/scs/contenidoGenerico.jsp?idDocument=ba5d4671-60dc-11ed-9e04-cd68079ec7ca&idCarpeta=61e907e3-d473-11e9-9a19-e5198e027117"
+    "website": "https://www3.gobiernodecanarias.org/sanidad/scs/contenidoGenerico.jsp?idDocument=ba5d4671-60dc-11ed-9e04-cd68079ec7ca&idCarpeta=61e907e3-d473-11e9-9a19-e5198e027117",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3265,7 +3273,11 @@
     "parents": ["Universidade de Vigo", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "http://www.observatorioredlocalis.com"
+    "website": "http://www.observatorioredlocalis.com",
+    "coordinates": {
+      "lat": 42.2376602,
+      "lon": -8.7247205
+    }
   },
   {
     "is_active": "Sí",
@@ -3273,7 +3285,11 @@
     "parents": ["Junta de Andalucía"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/observatorio-andaluz-de-publicidad-no-sexista"
+    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/observatorio-andaluz-de-publicidad-no-sexista",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de la Comunidad de Madrid contra el Racismo y la Intolerancia",
@@ -3358,7 +3374,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.ajsosteniblebcn.cat/ca/observatori-a-s_99532"
+    "website": "https://www.ajsosteniblebcn.cat/ca/observatori-a-s_99532",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Realización de eventos y actos de difusión de los resultados de los estudios realizados.",
@@ -3566,7 +3586,11 @@
     "stop_date": "a dìa de hoy sigue funcionando. Publica algunas excel con datos hasta al menos 2023",
     "type": "publico",
     "email": "oscn@navarra.es",
-    "website": "https://portalsalud.navarra.es/es/observatorio"
+    "website": "https://portalsalud.navarra.es/es/observatorio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": [
@@ -3679,7 +3703,11 @@
     "name": "Observatorio Andaluz de Violencia de Género",
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/2013-08-08-10-31-21/observatorio-andaluz-de-violencia-de-genero"
+    "website": "https://www.juntadeandalucia.es/institutodelamujer/index.php/2013-08-08-10-31-21/observatorio-andaluz-de-violencia-de-genero",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "L’Observatori de salut i impacte de polítiques (OBSIP) és una eina que permet fer un seguiment: (1) de l’estat de la salut a la ciutat i de les desigualtats existents entre barris i grups socials i (2) de l’impacte en salut de determinades polítiques dutes a terme per l’Ajuntament.",
@@ -3692,7 +3720,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://ajuntament.barcelona.cat/observatorisalut"
+    "website": "https://ajuntament.barcelona.cat/observatorisalut",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Grupo de trabajo, consultivo, asesor y de colaboración entre la administración de la Junta de Comunidades de Castilla-La Mancha y las organizaciones representativas del comercio, del ámbito de la economía digital, y las organizaciones más representativas de las personas trabajadoras del sector, que servirá para dar apoyo a los actores implicados en la comprensión de las dinámicas del comercio regional y afrontar nuevos retos.",
@@ -3771,7 +3803,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://iam.asturias.es/observatorio-de-igualdad-de-oportunidades"
+    "website": "https://iam.asturias.es/observatorio-de-igualdad-de-oportunidades",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatori de l'economia local de Sabadell",
@@ -3791,7 +3827,11 @@
     "description": "La sociedad cambia constantemente y una administración responsable necesita herramientas que permitan vigilar este cambio, medir la eficiencia de las medidas adoptadas, descubrir los problemas y las oportunidades de mejora. Para vigilar esta transformación, mejorar en la toma de decisiones y por transparencia, decidimos crear el OBSERVATORIO DE TRANSFORMACIÓN DIGITAL DE NAVARRA.\n\nEn este espacio compartiremos los principales indicadores de transformación digital de nuestra comunidad en los ejes de [personas](https://observatoriotransformaciondigital.navarra.es/es/personas), [gobierno](https://observatoriotransformaciondigital.navarra.es/es/gobierno), [empresas](https://observatoriotransformaciondigital.navarra.es/es/empresas) e [infraestructuras](https://observatoriotransformaciondigital.navarra.es/es/infraestructuras), así como otras [acciones](https://observatoriotransformaciondigital.navarra.es/es/acciones) relacionadas.\n\nEstos datos nos darán una medida del progreso de Navarra, comparándola, siempre que exista el dato, con España y Europa.",
     "scope": "autonómico",
     "parents": ["Gobierno de Navarra - Nafarroako Gobernua"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio de Servicios Sociales y Dependencia se configura como un órgano colegiado, de composición interdepartamental, con funciones asesoras, de investigación, formación y trasferencia del conocimiento en materia de servicios sociales y dependencia; que ejercerá sus funciones con plena autonomía y sin dependencia funcional de ningún órgano. El Observatorio pretende contribuir también a la reflexión y mejora de la práctica profesional, promoviendo el trabajo interdisciplinar, un buen clima laboral que cuide a las personas cuidadoras, la agilización y simplificación de trámites, la formación continua, así como la evaluación de procesos y resultados.",
@@ -3871,7 +3911,11 @@
         "name": "Observatorio económico mensual de la provincia de Jaén"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.9553976,
+      "lon": -3.4937431
+    }
   },
   {
     "email": "info@fepa18.org",
@@ -4080,7 +4124,11 @@
     "parents": ["Ayuntamiento de Madrid"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Observatorio-de-la-Ciudad/?vgnextfmt=default&vgnextchannel=ec38d941c9b25710VgnVCM2000001f4a900aRCRD"
+    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Observatorio-de-la-Ciudad/?vgnextfmt=default&vgnextchannel=ec38d941c9b25710VgnVCM2000001f4a900aRCRD",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Este Observatorio tiene sobre la mesa los retos identificados para la industria en la región: el crecimiento de la internacionalización de un sector que es responsable de uno de cada tres euros de las exportaciones de la Comunidad Autónoma, así como la digitalización, la sostenibilidad y la innovación en la industria.",
@@ -4156,7 +4204,11 @@
     "parents": ["Ayuntamiento de Badajoz"],
     "stop_date": "El último informe es de 2015",
     "type": "publico",
-    "website": "https://www.aytobadajoz.es/es/empleo/estudios-y-estadisticas/observatorio-del-cambio"
+    "website": "https://www.aytobadajoz.es/es/empleo/estudios-y-estadisticas/observatorio-del-cambio",
+    "coordinates": {
+      "lat": 38.878187,
+      "lon": -6.9701115
+    }
   },
   {
     "description": "Es una herramienta de información permanente y actual sobre el mercado de trabajo de la región, que nace con el objetivo de orientar sobre las demandas de empleo y formativas que surjan en determinados momentos y puntos de la comunidad autónoma.",
@@ -4391,7 +4443,11 @@
     "name": "Observatorio del Cambio Climático / Observatori del Canvi Climàtic",
     "parents": ["Ayuntamiento de Valencia"],
     "type": "publico",
-    "website": "https://climaienergia.com/observatori/"
+    "website": "https://climaienergia.com/observatori/",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "El Observatorio de CPR de Canarias es un órgano de asesoramiento, control y estudio respecto a la contratación pública para la sociedad civil y agentes involucrados.",
@@ -4513,7 +4569,11 @@
     "parents": ["Ayuntamiento de Málaga"],
     "scope": "local",
     "type": "publico",
-    "website": "https://movilidad.malaga.eu/es/lineas-de-trabajo/movima/"
+    "website": "https://movilidad.malaga.eu/es/lineas-de-trabajo/movima/",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    }
   },
   {
     "description": "Es un órgano colegiado adscrito a la Concejalía de Bienestar Social del Ayuntamiento de Fuenlabrada, cuya misión es convertirse en referente para la medición, seguimiento, evaluación, análisis y difusión de información sobre el desarrollo de la Ley 39/2006, de 14 de diciembre, de Promoción de la Autonomía Personal y Atención a las personas en situación de dependencia.\n\nEl Observatorio, recopila y difunde el conjunto de conocimientos, experiencias y buenas prácticas, ofreciendo una visión global y permanente de la situación y evolución de la Ley, que permite evaluar su impacto y el cumplimiento del mapa de recursos y servicios que determina, así como trasladar a otras administraciones la información que mejore la aplicación de la citada Ley.\n\nFunciones del Observatorio\n\n1. Constituir una base de información que pueda dar cuenta de la situación de la aplicación de la Ley a nivel local.\n\n2. Analizar las nuevas tendencias y cambios que se vayan produciendo en la aplicación de la Ley y factores asociados.\n\n3. Realizar investigaciones y estudios preparatorios y de viabilidad, organizar reuniones de técnicos y usuarios, y crear, si fuera necesario grupos de trabajo.\n\n4. Difundir los procesos anteriores y elaborar publicaciones e informes de carácter periódico sobre la temática.\n\n5. Facilitar el intercambio de información sobre la aplicación de la Ley con otros municipios y agentes sociales como empresas del sector, vecinos, técnicos, sindicatos, partidos políticos.\n\n6. Proponer un mapa de recursos lo que supondrá una mayor apuesta por la calidad.",
@@ -4572,7 +4632,11 @@
       "Área de Turismo de Málaga"
     ],
     "type": "publico",
-    "website": "https://visita.malaga.eu/profesional/es/observatorio-turistico"
+    "website": "https://visita.malaga.eu/profesional/es/observatorio-turistico",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    }
   },
   {
     "description": "Es una entidad dedicada a la recopilación y análisis de datos sobre la movilidad en Cataluña, abarcando aspectos como el transporte de personas y mercancías, sostenibilidad, infraestructuras y economía del transporte. Su objetivo es proveer información útil y servir como foro de análisis para atender las necesidades de sus usuarios.",
@@ -4739,7 +4803,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://www.castillalamancha.es/gobierno/agriaguaydesrur/estructura/dgalimentacion/titular/observatorio-precios-cadena-agroalimentaria"
+    "website": "https://www.castillalamancha.es/gobierno/agriaguaydesrur/estructura/dgalimentacion/titular/observatorio-precios-cadena-agroalimentaria",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Facilita que las personas consumidoras tomen decisiones de compra informadas con arreglo a criterios económicos.",
@@ -4783,14 +4851,22 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://consumo.castillalamancha.es/node/23956"
+    "website": "https://consumo.castillalamancha.es/node/23956",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "is_active": "None",
     "name": "Observatorio Aragonés de Dinamización Demográfica y Poblacional",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://observatoriopoblacion.aragon.es/"
+    "website": "https://observatoriopoblacion.aragon.es/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -4808,7 +4884,11 @@
     "name": "Observatorio Aragonés por la Convivencia y Contra el Acoso Escolar",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://educa.aragon.es/-/convivencia-web-basico-enlaces"
+    "website": "https://educa.aragon.es/-/convivencia-web-basico-enlaces",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -4816,7 +4896,11 @@
     "parents": ["Universidad de Zaragoza"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://oaaep.unizar.es/"
+    "website": "https://oaaep.unizar.es/",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "description": "El objetivo de este proyecto es no solo identificar, cartografiar y perfilar los desiertos alimentarios y de ejercicio físico en zonas rurales, si no también definir el concepto de desierto rural de ejercicio físico, explorar estrategias para mejorar la salud y el bienestar de las personas que viven en zonas rurales, y colaborar con las comunidades, empresas y servicios para abordar las inequidades que sufren las personas que viven en áreas rurales despobladas, desatendidas y, a menudo, desfavorecidas. Los resultados de esta investigación serán publicados a través del Observatorio Europeo de Desiertos Alimentarios y de Ejercicio Físico en Zonas Rurales.\n\nEl proyecto DESERT, con un presupuesto total de 638.591€, ha sido cofinanciado por la Unión Europea a través del programa E4Health Partnership y durará 3 años (2024-2027). Ambos socios reciben fondos del Instituto de Salud Carlos III, a través de la AES 2023, con código AC23_2/00039 y AC23_2/00003 en el marco de Partnership Fostering a European Research Area for Health (ERA4Health) GA nº 101095426 del Programa de Investigación e Innovación Horizonte Europa de la Unión Europea.\n\nNoticias sobre la creación de un Observatorio Europeo de Desiertos Rurales Alimentarios y de Ejercicio Físico:\r\n1. [Universidad de Zaragoza](https://ucc.unizar.es/noticia/aragon-impulsara-la-creacion-de-un-observatorio-europeo-de-desiertos-rurales-alimentarios-y)\r\n2. [Heraldo de Aragón](https://www.heraldo.es/noticias/aragon/2024/05/13/aragon-impulsara-creacion-observatorio-europeo-desiertos-rurales-alimentarios-ejercicio-fisico-1733325.html)\r\n3. [Agenda de la reunión (PDF)](https://www.iisaragon.es/wp-content/uploads/2024/05/DESERT-Kick-off.pdf)\n\n- Universidad de Zaragoza (pública)\r\n- Instituto de Investigación Sanitaria de Aragón (IISA) ([pública](https://contrataciondelestado.es/wps/poc?uri=deeplink%3AperfilContratante&idBp=%2F5d2hWOr17umq21uxhbaVQ%3D%3D))",
@@ -4848,7 +4932,11 @@
     "parents": ["Gobierno de Canarias", "Dirección General de Juventud"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/juventud/programas/observatorio-canario-de-la-juventud/"
+    "website": "https://www.gobiernodecanarias.org/juventud/programas/observatorio-canario-de-la-juventud/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "from_date": "2011",
@@ -4923,7 +5011,11 @@
         "name": "En las memorias, se especifican https://observatoridesc.org/es/transparencia"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "docs": [
@@ -5046,7 +5138,11 @@
     "parents": ["Cabildo de Tenerife"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.deportestenerife.es/oficina-virtual/observatorio-de-la-bicicleta/"
+    "website": "https://www.deportestenerife.es/oficina-virtual/observatorio-de-la-bicicleta/",
+    "coordinates": {
+      "lat": 43.4934282,
+      "lon": -3.5689291
+    }
   },
   {
     "is_active": "None",
@@ -5169,7 +5265,11 @@
     "name": "Observatorio de la Escuela Rural de Aragón",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://educa.aragon.es/-/innovacion/observatorio-rural"
+    "website": "https://educa.aragon.es/-/innovacion/observatorio-rural",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -5204,7 +5304,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/estudios-1"
+    "website": "https://www.aragon.es/-/estudios-1",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio para la Innovación de los Informativos en la Sociedad Digital",
@@ -5335,7 +5439,11 @@
     "parents": ["Junta de Andalucía"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.sspa.juntadeandalucia.es/servicioandaluzdesalud/todas-noticia/constituido-el-observatorio-de-agresiones-profesionales-del-sistema-sanitario-publico"
+    "website": "https://www.sspa.juntadeandalucia.es/servicioandaluzdesalud/todas-noticia/constituido-el-observatorio-de-agresiones-profesionales-del-sistema-sanitario-publico",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "is_active": "None",
@@ -5425,7 +5533,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-aragones-de-familia"
+    "website": "https://www.aragon.es/-/observatorio-aragones-de-familia",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "El Observatorio tratará de desarrollar tres líneas fundamentales: generar un espacio de conocimiento sobre la información en salud en Asturias a través de una serie de informes periódicos; garantizar que esta información llegue de la forma más comprensible al mayor número de agentes de salud posibles, destacando la importancia de un abordaje de los determinantes sociales de la salud y, finalmente, vincular la información en salud de los indicadores a las diferentes actuaciones comunitarias en salud que se están desarrollando en Asturias.\n\nDirección General de Salud Pública. Consejería de Sanidad. Gobierno del Principado de Asturias.\r\nSupervisión: School of Public Health and Medicine de la Universidad de Wisconsin-Madison.",
@@ -5570,7 +5682,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.educantabria.es/diversidad/convivencia"
+    "website": "https://www.educantabria.es/diversidad/convivencia",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "El Observatorio de la cuenca Saja-Besaya, denominado Observatorio SABE, es un órgano independiente, de carácter técnico y multidisciplinar, que trabaja por implementar mejoras en nuestros ecosistemas, paisajes, estuarios, zonas forestales o urbanas, entre otras.\n\nConsejo Asesor:\n\n> El Consejo Asesor está compuesto por Soledad Nogués, profesora titular de Urbanística y Ordenación del Territorio de la Universidad de Cantabria y Torrelaveguense ilustre 2016, Jesús Tortosa, Director General de la Cámara de Comercio de Cantabria, Leandro Morante, exdirector del CIMA de Torrelavega, Sonsoles Pérez, Jefa de seguridad, higiene, medio ambiente y calidad de Solvay, Felipe González, delegado en Cantabria de SEO Birdlife, y Fernando Isasi, Director gerente de la Red Cántabra de Desarrollo Rural.\n\nConsejo Rector:\n\n>  14 personas (6 de las entidades incorporadas, 6 del Consejo Asesor y 2 de la secretaría y dirección).",
@@ -5589,7 +5705,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://observatoriosabe.es"
+    "website": "https://observatoriosabe.es",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "La confianza de los ciudadanos en las instituciones públicas se gana con dificultad y se pierde fácilmente. Lo ideal es que las instituciones públicas actúen de manera socialmente responsable y ética para ganar y mantener la confianza de los ciudadanos en las instituciones públicas y políticas.\n\nLos ciudadanos activos son cruciales en la lucha contra la corrupción: llaman la atención sobre la gravedad de este problema, elevan la conciencia pública sobre su impacto, y actúan como vigilantes efectivos de cargos públicos y partidos monitorizándolos y manteniéndolos bajo un escrutinio constante en términos de rendición de cuentas y capacidad de respuesta. Esto conduce poco a poco a un mecanismo de autocontrol, ya que obliga a los cargos y funcionarios públicos a comportarse éticamente y ofrecer un gobierno limpio. Por el contrario, altos niveles de percepción de mala gobernanza o corrupción, conducen a la frustración de los ciudadanos con su sector público, a la apatía pública, a la falta de compromiso cívico y a la falta de confianza en el proceso político y democrático, y finalmente también al aumento del fraude fiscal, que es la otra cara de la misma moneda.\n\nLa Convención de las Naciones Unidas contra la Corrupción (UNCAC) proporciona la base para la participación ciudadana en los esfuerzos anticorrupción en el artículo 13, que obliga a los Estados miembros a «tomar las medidas adecuadas para promover la participación activa de individuos y grupos ajenos al sector público, como la sociedad civil, las organizaciones no gubernamentales y las organizaciones comunitarias, en la prevención y la lucha contra la corrupción «, y exige a los Estados miembros que proporcionen vías de participación pública en la toma de decisiones.\n\nEste Observatorio pretende contribuir dentro de sus posibilidades, a esta participación activa de la ciudadanía a favor de la transparencia en el diseño de las políticas públicas, y de la integridad en su ejecución.\n\nundefined",
@@ -5735,7 +5855,11 @@
     ],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://www.casaarabe.es/eventos-arabes/show/observatorio-de-finanzas-islamicas-en-espana"
+    "website": "https://www.casaarabe.es/eventos-arabes/show/observatorio-de-finanzas-islamicas-en-espana",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El “Observatorio Agenda Provincia de Cáceres” se concibe con el objetivo de integrar de forma estructurada tanto la información socioeconómica, como la generada en las distintas acciones incluidas en el Plan de Acción de Diputación de Cáceres.\n\nEste observatorio permitirá realizar el seguimiento de la evolución de los indicadores registrados actualmente y de aquellos que se incorporen durante la consecución de las acciones incluidas en el Plan de Acción de Diputación de Cáceres, constituyendo una herramienta fundamental tanto para las tareas de planificación de Diputación de Cáceres como para la transferencia de resultados a la ciudadanía.",
@@ -5817,7 +5941,11 @@
     "parents": ["Ayuntamiento de Alcoy"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.alcoyturismo.com/pag/4174/observatorio-turistico.html"
+    "website": "https://www.alcoyturismo.com/pag/4174/observatorio-turistico.html",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    }
   },
   {
     "is_active": "Si",
@@ -5859,7 +5987,11 @@
     "parents": ["Instituto De Seguridade E Saúde Laboral De Galicia - Issga"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://issga.xunta.gal/gl/observatorio"
+    "website": "https://issga.xunta.gal/gl/observatorio",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Nacional del Software de Fuentes Abiertas (ONSFA)",
@@ -5969,7 +6101,11 @@
       {
         "url": "https://www.valencia.es/documents/d/guest/informe-tasa-de-paro-agosto-2025-pdf"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "Este Observatorio tiene como objetivo proporcionar claves sobre la calidad del sistema universitario español que puedan contribuir a la reflexión de diversos agentes interesados para la mejora de la calidad del mismo.",
@@ -6030,7 +6166,11 @@
     "parents": ["Ayuntamiento de Alcoy"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.alcoi.org/es/areas/sanidad/bienestar_animal/observatorio_proteccion.html"
+    "website": "https://www.alcoi.org/es/areas/sanidad/bienestar_animal/observatorio_proteccion.html",
+    "coordinates": {
+      "lat": 38.6982348,
+      "lon": -0.4747619
+    }
   },
   {
     "is_active": "Si",
@@ -6085,7 +6225,11 @@
     "parents": ["Ayuntamiento de Albacete"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.albacete.es/es/empleo-promocion-economica/empleo/observatorio-empleo"
+    "website": "https://www.albacete.es/es/empleo-promocion-economica/empleo/observatorio-empleo",
+    "coordinates": {
+      "lat": 38.9950921,
+      "lon": -1.8559154
+    }
   },
   {
     "description": "El Observatorio Social de Álava se crea precisamente como una herramienta de información complementaria sobre la actividad de los Servicios Sociales en el Territorio Histórico. A través de esta web, la Diputación Foral de Álava pretende poner a disposición de los técnicos que trabajan en el área de Bienestar Social y de la ciudadanía en general un núcleo de datos estadísticos que permitan:\nConocer las principales magnitudes de la red alavesa de Servicios Sociales.\nRealizar comparaciones entre diferentes cuadrillas y/o municipios.\nValorar la adecuación de los recursos disponibles a las necesidades presentes en el Territorio Histórico.\nEvaluar la adecuación de los servicios en referencia a una serie de estándares de buena práctica.\nRealizar un seguimiento de la evolución de los Servicios Sociales en el Territorio Histórico.",
@@ -6158,7 +6302,11 @@
     ],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-aragones-de-consumo"
+    "website": "https://www.aragon.es/-/observatorio-aragones-de-consumo",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Para <q>recabar la información necesaria sobre el turismo y ponerla a disposición de la industria turística del territorio para que esta pueda tomar las decisiones más adecuadas y anticiparse a los retos del sector</q>",
@@ -6174,7 +6322,11 @@
     "parents": ["Ayuntamiento de València"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.valencia.es/cas/actualidad/-/content/observatorio-social-1"
+    "website": "https://www.valencia.es/cas/actualidad/-/content/observatorio-social-1",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "description": "Es <q>el órgano que de una manera estructurada y planificada recoge, gestiona, procesa y genera estudios relacionados con el ámbito de la juventud</q>.",
@@ -6229,7 +6381,11 @@
     "parents": [
       "Consejería de Presidencia, Reto Demográfico, Igualdad y Turismo (Gobierno de Asturias)"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Creado en 2016, está constituido por un grupo de trabajo cuya finalidad es el estudio, la investigación, la formación, la divulgación, la promoción y la elaboración de estrategias para la Cooperación para el Desarrollo y la Educación para la Ciudadanía Global en la provincia de Zaragoza.",
@@ -6261,7 +6417,11 @@
     "parents": ["Gobierno de Cantabria"],
     "scope": "cantabria",
     "type": "publico",
-    "website": "https://www.cantabria.es/web/comunicados/w/el-gobierno-creará-un-observatorio-de-transición-generacional-para-afrontar-el-mayor-desafío-al-que-se-enfrenta-el-sector-agrario-de-cantabria"
+    "website": "https://www.cantabria.es/web/comunicados/w/el-gobierno-creará-un-observatorio-de-transición-generacional-para-afrontar-el-mayor-desafío-al-que-se-enfrenta-el-sector-agrario-de-cantabria",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "name": "Observatorio de tecnología educativa",
@@ -6332,7 +6492,11 @@
       {
         "url": "https://www.valencia.es/documents/20142/52352/Folleto%2520OMAV%2520cas-1.pdf/7260ab13-d095-c0c0-dc1b-4bde87943718"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio de Sostenibilidad Turística de Galicia",
@@ -6374,7 +6538,11 @@
     "scope": "aragon",
     "parents": ["Instituto Aragonés de Empleo (INAEM)"],
     "is_active": "Si",
-    "description": "El Observatorio de Mercado de Trabajo del INAEM es un servicio público de información y análisis del mercado de trabajo en Aragón, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio de Mercado de Trabajo del INAEM es un servicio público de información y análisis del mercado de trabajo en Aragón, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio mercado de trabajo",
@@ -6383,7 +6551,11 @@
     "scope": "asturias",
     "parents": ["Gobierno del Principado de Asturias"],
     "is_active": "Si",
-    "description": "El Observatorio de Mercado de Trabajo del Principado de Asturias es un servicio público de información y análisis del mercado de trabajo en Asturias, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio de Mercado de Trabajo del Principado de Asturias es un servicio público de información y análisis del mercado de trabajo en Asturias, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
@@ -6632,7 +6804,11 @@
     "type": "publico",
     "website": "https://www.dipusevilla.es/la-diputacion/areas/area-de-cohesion-social-e-igualdad/Servicio-de-Igualdad-y-Diversidad/observatorio-para-la-igualdad-y-la-diversidad/el-observatorio/",
     "is_active": "Sí",
-    "email": "No disponible"
+    "email": "No disponible",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio de Transición Justa de Asturias (OTJA)",
@@ -6690,7 +6866,11 @@
     "from_date": "Anunciado el 30 / diciembre/ 2024.",
     "parents": [
       "Consejo Extremeño de Promoción de la Accesibilidad Universal de laJunta de Extremadura."
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Violencia Machista en Bizkaia",
@@ -6875,7 +7055,11 @@
     ],
     "is_active": "Sí",
     "email": "observatorijove@gva.es",
-    "from_date": "Ley 15/2017 de la Generalitat"
+    "from_date": "Ley 15/2017 de la Generalitat",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatori Simbiosi Industrial de la Comunitat Valenciana (OSICV)",
@@ -6978,7 +7162,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2011"
+    "from_date": "2011",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Permanente",
@@ -7049,7 +7237,11 @@
     "scope": "barcelona",
     "type": "publico",
     "website": "https://ajuntament.barcelona.cat/dretssocials/ca/content/observatori-social-bcn",
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Bilbao Observatorio (Bilbao Ekintza)",
@@ -7088,7 +7280,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2021"
+    "from_date": "2021",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatori del Canvi Climàtic (Valencia)",
@@ -7217,7 +7413,11 @@
     "scope": "local",
     "type": "publico",
     "is_active": "No",
-    "from_date": "2024-01-09 (Propuesto)"
+    "from_date": "2024-01-09 (Propuesto)",
+    "coordinates": {
+      "lat": 40.3281942,
+      "lon": -3.76527
+    }
   },
   {
     "name": "Observatorio de la Movilidad de Rivas-Vaciamadrid",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -36,7 +36,11 @@
     "parents": ["Diputación de Granada"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://opaugranada.es/"
+    "website": "https://opaugranada.es/",
+    "coordinates": {
+      "lat": 37.1734995,
+      "lon": -3.5995337
+    }
   },
   {
     "docs": [
@@ -182,11 +186,19 @@
     "from_date": "25-01-2018",
     "name": "Observatorio Autonómico dos Ríos de Galicia",
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Sociedade da Información e a Modernización de Galicia",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Violencia no Contorno Laboral",
@@ -219,7 +231,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://oteagranada.com/"
+    "website": "https://oteagranada.com/",
+    "coordinates": {
+      "lat": 37.1734995,
+      "lon": -3.5995337
+    }
   },
   {
     "description": "Es una entidad que supervisa y reporta el progreso y estado de la administración electrónica en España. Publica mensualmente un boletín con indicadores clave, recolectando datos propios y de terceros para ofrecer una visión completa del desarrollo y avance de la digitalización de los servicios administrativos en el país. Su función principal es proporcionar información actualizada y relevante que ayude en la transformación digital y mejora de la administración electrónica.",
@@ -318,7 +334,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://observatoricullera.uv.es/"
+    "website": "https://observatoricullera.uv.es/",
+    "coordinates": {
+      "lat": 39.1647217,
+      "lon": -0.2542313
+    }
   },
   {
     "name": "Observatorio de la Infancia de España",
@@ -354,7 +374,11 @@
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de Asturias",
-    "scope": "asturias"
+    "scope": "asturias",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatorio de Políticas del Agua (OPPA)",
@@ -498,7 +522,11 @@
     ],
     "scope": "cantabria",
     "type": "publico",
-    "website": "https://fmvaldecilla.es/unidad/observatorio-de-salud-publica-de-cantabria/"
+    "website": "https://fmvaldecilla.es/unidad/observatorio-de-salud-publica-de-cantabria/",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "Nace <q>como un órgano colegiado intersectorial para apoyar el análisis, diagnóstico, evaluación y seguimiento de los efectos de la emergencia climática en la salud, al tiempo que ofrece apoyo científico-técnico a las Administraciones públicas</q>.",
@@ -594,7 +622,11 @@
     "name": "Observatorio do Sector Lácteo de Galicia",
     "scope": "galicia",
     "type": "publico",
-    "website": "https://fogga.xunta.gal/es/sector_lacteo/observatorio_del_sector_lacteo"
+    "website": "https://fogga.xunta.gal/es/sector_lacteo/observatorio_del_sector_lacteo",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "docs": [
@@ -651,7 +683,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://occet.es/"
+    "website": "https://occet.es/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio Español contra la LGBTfobia"
@@ -795,7 +831,11 @@
     ],
     "scope": "autonómico",
     "type": "mixto",
-    "website": "https://www.odina.es"
+    "website": "https://www.odina.es",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Observatorio Estatal de la Dependencia",
@@ -1085,7 +1125,11 @@
     "parents": ["Consejo Social UPM"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.upm.es/observatorio/vi/index.jsp"
+    "website": "https://www.upm.es/observatorio/vi/index.jsp",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio para el Análisis y Visibilidad de la Exclusión Social , nace con el propósito de investigar situaciones, procesos y estructuras de exclusión social, darles visibilidad con campañas de comunicación y crear proyectos de intervención para colaborar en su erradicación. Se materializa así, como una manifestación más de la responsabilidad social universitaria, el firme compromiso de la Universidad Rey Juan Carlos en apostar por la igualdad de todas las personas, así como en la generación de oportunidades vitales para ellas. Este Observatorio está formado por un grupo interdisciplinar de PDIs, liderados desde la Sociología (investigación social) y el Trabajo Social (intervención social) de esta Universidad. Por su parte, el Grupo IDEX, líder en comunicación social, será el socio externo que implementaría la estrategia de difusión y sensibilización de la realidad investigada, financiándose a través de RSC de empresas. Se une la Universidad y la sociedad civil en la mejora de la calidad de vida de las personas más vulnerables.\n\nOBJETIVOS:\n\nInvestigar y analizar situaciones, procesos y estructuras de exclusión social.\r\nLanzar campañas mediáticas para sensibilizar a la sociedad en general, de las situaciones, procesos y estructuras de exclusión social previamente estudiadas.\r\nGenerar proyectos de intervención social para los fenómenos analizados.",
@@ -1221,7 +1265,11 @@
     "scope": "local",
     "to_date": "Continúa",
     "type": "publico",
-    "website": "https://www.alicante.es/es/gobierno-abierto/transparencia/conceptos/observatorio-calidad-servicios-municipales"
+    "website": "https://www.alicante.es/es/gobierno-abierto/transparencia/conceptos/observatorio-calidad-servicios-municipales",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "name": "Observatorio Tecnológico",
@@ -1243,7 +1291,11 @@
         "name": "Informe de Transformación Urbana de Sevilla 2022"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio Territorial de Andalucía",
@@ -1295,7 +1347,11 @@
     "parents": [
       "Consellería de presidencia, Xustiza e Deportes",
       "Xunta de Galicia"
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "1. Este observatorio, para a consecución dos seus fins, exercerá as seguintes funcións:\n\na) Actuar como órgano de recompilación, análise e intercambio da información dispoñible en diferentes fontes autonómicas, estatais e internacionais sobre a familia e os nenos, nenas e adolescentes.\n\nb) Propoñer a realización de estudos, investigacións e informes técnicos que permitan un mellor coñecemento da situación da familia e da infancia en Galicia e a detección das súas necesidades e demandas sociais.\n\nc) Avaliar o impacto das políticas fiscais, laborais e sociais desenvolvidas polos distintos departamentos das administracións na situación das familias e da infancia galegas.\n\nd) Formular propostas e recomendacións sobre liñas estratéxicas e prioridades de actuación en materia de políticas familiares e de infancia no ámbito da Comunidade Autónoma Galega.\n\ne) Servir de canle para a actuación coordinada e harmónica entre os distintos departamentos das administracións públicas no ámbito da familia e a infancia.\n\nf) Canalizar as propostas das organizacións sociais que desenvolven as súas actividades no ámbito da familia e da infancia.\n\ng) Promover as actuacións necesarias para sensibilizar a toda a cidadanía no coñecemento e respecto dos dereitos da infancia en Galicia e no mundo.\n\nh) Promover a elaboración e desenvolvemento dos plans e estratexias de familia, de infancia e adolescencia e avaliar a súa execución.\n\ni) Elaborar informes e ditames por petición dos órganos competentes da Comunidade Autónoma sobre as materias da súa competencia.\n\nj) Impulsar a incorporación da perspectiva da familia e infancia no ordenamento xurídico galego, de xeito que se tomen en consideración as necesidades da infancia, da adolescencia e das familias galegas.\n\nk) Participar, elevar propostas e manter contactos con outros órganos de similar natureza, promovendo os encontros entre profesionais e persoas expertas, tanto no ámbito autonómico e estatal como internacional, para facilitar o intercambio de experiencias, investigacións e traballos nesta materia.\n\n2. No exercicio das funcións establecidas neste artigo terase en conta e integrarase de xeito transversal a perspectiva de xénero e a relación recíproca entre familia e infancia e igualdade de xénero.\n\ntitular da consellería competente en materia de familia\r\n titular da dirección xeral competente en materia de familia\r\n funcionaria da consellería competente en materia de familia\r\n persoa en representación do órgano competente en materia de estatística\r\npersoa en representación da Delegación do Goberno en Galicia\r\npersoa en representación da Federación Galega de Municipios e Provincias (Fegamp)\r\npersoa en representación de cada unha das tres universidades galegas\r\npersoa representante da Fiscalía da Comunidade Autónoma de Galicia\r\nUn número de persoas equivalente ao de representantes sindicais en representación da Confederación de Empresarios de Galicia (CEG)\r\npersoa en representación de cada unha das organizacións sindicais intersectoriais máis representativas de Galicia, así como das presentes na Mesa Xeral de Negociación das Administracións Públicas que non teñan a condición de máis representativas\r\npersoa representante da Plataforma de Organizacións da Infancia de Galicia (POI Galicia)\r\npersoa en representación da Fundación UNICEF-Comité Español",
@@ -1366,7 +1422,11 @@
     ],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.observatoriodavivenda.gal"
+    "website": "https://www.observatoriodavivenda.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio da Lingua Galega",
@@ -1570,7 +1630,11 @@
         "name": "La Diputación de Badajoz pone a disposición una plataforma online interactiva con datos socioeconómicos de la provincia",
         "url": "https://www.dip-badajoz.es/agenda/index.php?id=3&agenda=21524"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 38.878187,
+      "lon": -6.9701115
+    }
   },
   {
     "name": "Observatorio Ocupacional y Empresarial de ILDEFE",
@@ -1677,7 +1741,11 @@
     "parents": ["Gobierno de la Región de Murcia"],
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=740&IDTIPO=140"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=740&IDTIPO=140",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de Turismo de Extremadura",
@@ -1751,7 +1819,11 @@
         "name": "Orden de 1 de febrero de 2007 de la Consejería de Sanidad por el que se crea el Observatorio sobre Drogas de la Región de Murcia.",
         "url": "https://www.murciasalud.es/-/legislacion-97389"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatori Balear de la Societat de la Informació (OBSI)",
@@ -1876,7 +1948,11 @@
     "parents": ["Universidad de Vigo"],
     "scope": "autonómico",
     "type": "mixto",
-    "website": "observatorio.eolico.uvigo.es"
+    "website": "observatorio.eolico.uvigo.es",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "location": "A Coruña",
@@ -2005,7 +2081,11 @@
     "parents": [
       "Consellería de Cultura, Lengua y Juventud de la Xunta de Galicia"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "location": "Alcalá de Henares",
@@ -2250,7 +2330,11 @@
       {
         "name": "Encuesta continua del Observatorio Turístico de la Provincia de Sevilla"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Observatorio para la Prevención del Tabaquismo",
@@ -2399,7 +2483,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "website": "https://observatorioconvivencia.com/",
-    "description": "El Observatorio para la Convivencia Escolar es un órgano colegiado que sirve de instrumento a la comunidad educativa y a la sociedad para conocer, analizar y evaluar la convivencia en los centros docentes. Está adscrito a la Consejería de Educación y Cultura, a través de la Dirección General de Ordenación Académica. La finalidad del Observatorio será la de contribuir a la mejora del desarrollo de la actividad escolar en los centros docentes mediante la evaluación y el diagnóstico de la convivencia escolar, el análisis de los conflictos y la propuesta de medidas para la prevención de la violencia."
+    "description": "El Observatorio para la Convivencia Escolar es un órgano colegiado que sirve de instrumento a la comunidad educativa y a la sociedad para conocer, analizar y evaluar la convivencia en los centros docentes. Está adscrito a la Consejería de Educación y Cultura, a través de la Dirección General de Ordenación Académica. La finalidad del Observatorio será la de contribuir a la mejora del desarrollo de la actividad escolar en los centros docentes mediante la evaluación y el diagnóstico de la convivencia escolar, el análisis de los conflictos y la propuesta de medidas para la prevención de la violencia.",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Regional de la Discapacidad",
@@ -2420,7 +2508,11 @@
     "parents": ["Consell de Mallorca"],
     "scope": "local",
     "type": "publico",
-    "website": "https://esports.conselldemallorca.es/observatori-esportiu-de-mallorca"
+    "website": "https://esports.conselldemallorca.es/observatori-esportiu-de-mallorca",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "docs": [
@@ -2432,7 +2524,11 @@
     "name": "Observatorio de la Calidad de los Servicios de la Comunidad Autónoma de la Región de Murcia",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-de-la-calidad-de-los-servicios#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-de-la-calidad-de-los-servicios#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de Igualdad",
@@ -2610,7 +2706,11 @@
     "parents": ["Dirección General de Salud Pública", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://observatoriosaudepublica.sergas.gal/es"
+    "website": "https://observatoriosaudepublica.sergas.gal/es",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "Para <q>informar sobre la evolución de los principales indicadores relativos a la sostenibilidad económica, social y medioambiental de la agricultura de regadío en España</q>.",
@@ -2639,7 +2739,11 @@
     "parents": ["Diputación de Alicante"],
     "scope": "provincial",
     "type": "publico",
-    "website": "http://dipalicante.gobiernoabierto.femp.es/es/municipios/municipios/inicio"
+    "website": "http://dipalicante.gobiernoabierto.femp.es/es/municipios/municipios/inicio",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "description": "El Observatorio Coruñés contra a LGTBIfobia es un servicio dedicado a la escucha, asesosamiento, registro y denuncia de los incidentes o delitos de odio con un componente LGTBIfobico.",
@@ -2976,7 +3080,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://oic.itccanarias.org/"
+    "website": "https://oic.itccanarias.org/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -2992,7 +3100,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/turismo/estadisticas_y_estudios/"
+    "website": "https://www.gobiernodecanarias.org/turismo/estadisticas_y_estudios/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3008,7 +3120,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www3.gobiernodecanarias.org/ceic/energia/oecan/"
+    "website": "https://www3.gobiernodecanarias.org/ceic/energia/oecan/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3016,7 +3132,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.obidic.es"
+    "website": "https://www.obidic.es",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatori agroalimentari, rural i ambiental",
@@ -3072,7 +3192,11 @@
     "parents": ["Instituto Galego da Vivenda e Solo", "Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.observatoriodosoloempresarial.gal"
+    "website": "https://www.observatoriodosoloempresarial.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "Para promover la participación de la sociedad en la mejora y desarrollo de la actividad comercial en Galicia.",
@@ -3081,7 +3205,11 @@
     "name": "Observatorio do Comercio de Galicia",
     "parents": ["Dirección Xeral de Comercio", "Xunta de Galicia"],
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "email": "observatoriodelaguaemasesa@emasesa.com",
@@ -3101,7 +3229,11 @@
     "parents": ["Xunta de Galicia", "Instituto Enerxético de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.inega.gal/es/inega/puntos-de-encuentro-energeticos/observatorios"
+    "website": "https://www.inega.gal/es/inega/puntos-de-encuentro-energeticos/observatorios",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio de Gestión de EUSKALIT es un servicio cuyo objetivo es identificar, analizar y recopilar la información destacada de todo el mundo sobre la gestión avanzada y hacérsela llegar de forma accesible a las organizaciones y otros grupos de interés de Euskadi, para así ampliar su conocimiento en este ámbito.",
@@ -3235,7 +3367,11 @@
     "name": "Observatorio Económico de Melilla",
     "parents": ["Consejería de Presidencia"],
     "scope": "melilla",
-    "website": "https://elfarodemelilla.es/echa-a-andar-el-observatorio-economico-de-melilla/"
+    "website": "https://elfarodemelilla.es/echa-a-andar-el-observatorio-economico-de-melilla/",
+    "coordinates": {
+      "lat": 35.2929115,
+      "lon": -2.9507202
+    }
   },
   {
     "description": "El Observatorio de precios agrarios muestra semanalmente la evolución del precio que percibe el productor (origen) y el que paga el consumidor (destino). También incorpora costes de producción de diferentes cultivos y especies ganaderas que se irán completando semana a semana.",
@@ -3256,7 +3392,11 @@
     "name": "Banda Ancha de Navarra",
     "scope": "navarra",
     "type": "publico",
-    "website": "https://bandaancha.navarra.es/es/inicio"
+    "website": "https://bandaancha.navarra.es/es/inicio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Facilita diversos estudios, directivas, información de y para operadores turísticos regionales",
@@ -3277,7 +3417,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://turismoprofesional.navarra.es/es/observatorio-turistico"
+    "website": "https://turismoprofesional.navarra.es/es/observatorio-turistico",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Órgano encargado de analizar y estudiar la situación de la población joven de la Comunidad Foral de Navarra. El trabajo que realizamos desde el observatorio joven permite analizar y evaluar la situación, demandas y necesidades de la juventud Navarra, para, de esta manera, poder diseñar, elaborar y evaluar diferentes iniciativas, políticas y estrategias destinadas a mejorar las condiciones de vida del colectivo joven.",
@@ -3340,7 +3484,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.nasuvinsa.es/es/servicios/lursarea/observatorio"
+    "website": "https://www.nasuvinsa.es/es/servicios/lursarea/observatorio",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio CIBIM revisa periódicamente la publicación de licitaciones públicas en la Plataforma de Contratación del Sector Público y plataformas existentes en Comunidades Autónomas, para identificar la incorporación de requisitos BIM y llevar a cabo un análisis cuantitativo y cualitativo de licitaciones con BIM publicadas en España a lo largo de los últimos años, según distintas clasificaciones.",
@@ -3404,7 +3552,11 @@
     "scope": "provincial",
     "to_date": "sigue",
     "type": "publico",
-    "website": "https://www.puertoalicante.com/negocio/observatorio/"
+    "website": "https://www.puertoalicante.com/negocio/observatorio/",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "email": "observatorioinfancia.assda@juntadeandalucia.es",
@@ -3521,7 +3673,11 @@
     "name": "Observatori de l'economia local de Sabadell",
     "scope": "local",
     "type": "mixto",
-    "website": "https://www.vaporllonch.cat/observatori-economia-local"
+    "website": "https://www.vaporllonch.cat/observatori-economia-local",
+    "coordinates": {
+      "lat": 41.5421013,
+      "lon": 2.1138977
+    }
   },
   {
     "name": "Observatorio deTransformación Digital de Navarra - Nafarroako Eraldaketa Digitalaren Behatokia",
@@ -3637,7 +3793,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://observatorisocial.tarragona.cat/"
+    "website": "https://observatorisocial.tarragona.cat/",
+    "coordinates": {
+      "lat": 41.1172364,
+      "lon": 1.2546057
+    }
   },
   {
     "description": "Para aportar información útil al agricultor como apoyo en sus procesos de toma de decisiones.",
@@ -4066,7 +4226,11 @@
     "website": "https://www.navarra.es/es/web/centro-documentacion-social",
     "type": "publico",
     "is_active": "Sí",
-    "email": "info.derechossociales@navarra.es"
+    "email": "info.derechossociales@navarra.es",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Como Observatorio la visión es poder tener varios objetivos fijados a largo plazo como concienciar la LGTBIfobia en la existente actual y erradicar contra la LGTBIfobia.",
@@ -4137,7 +4301,11 @@
     ],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://contratacionresponsablecanarias.org"
+    "website": "https://contratacionresponsablecanarias.org",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatori de l'Administració Digital",
@@ -4216,7 +4384,11 @@
     ],
     "scope": "menorca",
     "type": "publico",
-    "website": "https://www.obsam.cat"
+    "website": "https://www.obsam.cat",
+    "coordinates": {
+      "lat": 39.9492572,
+      "lon": 4.0499642
+    }
   },
   {
     "name": "Observatorio de la gestión del agua en España",
@@ -4249,7 +4421,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://diversidad-funcional.ayto-fuenlabrada.es/observatorio-municipal-de-la-dependencia.php"
+    "website": "https://diversidad-funcional.ayto-fuenlabrada.es/observatorio-municipal-de-la-dependencia.php",
+    "coordinates": {
+      "lat": 40.282476,
+      "lon": -3.7923422
+    }
   },
   {
     "name": "Observatorio Turístico de Alcobendas",
@@ -4274,7 +4450,11 @@
         "name": "Sumérgete en el Turismo Cultural de Alcobendas: ¡Un Destino Inolvidable!"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.5400082,
+      "lon": -3.6358494
+    }
   },
   {
     "description": "El objetivo de este informe estadístico, de carácter anual, es conocer de una forma completa e integrada las pautas de la visita y el perfil del visitante, tanto turistas como excursionistas, entre otros aspectos. Es decir, se trata de determinar los perfiles del visitante que llega a la ciudad de Málaga: cuáles son sus motivaciones iniciales, cómo organizan su viaje, qué tipo de actividades realizan durante su estancia, cómo valoran la oferta disponible y el viaje en función de sus expectativas iniciales, entre otros aspectos relevantes.",
@@ -4329,7 +4509,11 @@
       "Colegio de Sociología y Politología de Navarra"
     ],
     "scope": "navarra",
-    "website": "https://gobiernoabierto.navarra.es/es/participacion/enviar-aportacion/1587/observatorio-participacion-ciudadana-navarra"
+    "website": "https://gobiernoabierto.navarra.es/es/participacion/enviar-aportacion/1587/observatorio-participacion-ciudadana-navarra",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Es un órgano colegiado y consultivo que dependiendo de la Dirección General competente en materia de lucha contra la brecha digital trata de ser un foro de participación que permita el impulso compartido entre las administraciones públicas, los agentes económicos y sociales y la sociedad civil organizada en la lucha contra la brecha digital. Servirá de plataforma para planificar, estudiar y analizar el entorno y la realidad socioeconómica valenciana en materia de brecha digital.",
@@ -4375,7 +4559,11 @@
     "parents": ["Servicios sociales, empleo y vivienda", "Gobierno de Navarra"],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.observatoriorealidadsocial.es"
+    "website": "https://www.observatoriorealidadsocial.es",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Es <q>una herramienta para centralizar la información sobre accesibilidad en el País Vasco y que esté a disposición de todas las personas interesadas</q>.",
@@ -4424,7 +4612,11 @@
     "from_date": "15/01/2012",
     "parents": [
       "Puede encontrarse el anuncio de su creación en [este artículo del BOE](https://www.boe.es/buscar/act.php?id=BOE-A-2012-4187)."
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.5941788,
+      "lon": -5.5704747
+    }
   },
   {
     "docs": [
@@ -4604,7 +4796,11 @@
         "name": "- Aforos y balances de cultivos (Anual)."
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Desca",
@@ -4954,7 +5150,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.astursalud.es/noticias/-/noticias/observatorio-sobre-drogas-y-adiccion-a-las-bebidas-alcoholicas-del-principado-de-asturias"
+    "website": "https://www.astursalud.es/noticias/-/noticias/observatorio-sobre-drogas-y-adiccion-a-las-bebidas-alcoholicas-del-principado-de-asturias",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "is_active": "Sí",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -8776,18 +8776,6 @@
     }
   },
   {
-    "name": "Observatorio de aves (Dunas de Maspalomas)",
-    "description": "Observatorio de aves en el ámbito de las Dunas de Maspalomas (espacio/instalación de observación). <a href=\"https://cabildo.grancanaria.com/dunas/observatorio-de-aves\">Sitio web</a>.",
-    "parents": ["Cabildo de Gran Canaria"],
-    "scope": "canarias",
-    "type": "publico",
-    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves",
-    "coordinates": {
-      "lat": 27.9580004,
-      "lon": -15.6062305
-    }
-  },
-  {
     "name": "Fundación Canaria Observatorio de Temisas",
     "description": "Referencia a la Fundación Canaria Observatorio de Temisas en noticia de subvención del Cabildo (planetario). <a href=\"https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26\">Fuente</a>.",
     "parents": [

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -4,7 +4,11 @@
     "name": "Observatorio contra el Fraude y la Corrupción Sanitaria",
     "parents": ["Ministerio de Sanidad"],
     "scope": "estatal",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Para <q>la disminución de las desigualdades de género en salud, mediante la participación y colaboración entre el conjunto de agentes implicados, generando y difundiendo conocimiento que permita el análisis de género y promueva la inclusión del enfoque de género y la equidad en las políticas públicas de salud</q>.",
@@ -16,7 +20,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatoriosaludmujeres.es"
+    "website": "https://www.observatoriosaludmujeres.es",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Observatorio Provincial de todas las Agendas Urbanas Supramunicipales en la provincia de Granada\n\nSu objetivo es lograr:\r\n- La mejora de la calidad de vida de las personas.\r\n- La gestión eficiente de los servicios.\r\n- La sostenibilidad económica y ambiental.\r\n- El uso innovador de los recursos.\r\n- La innovación en las políticas públicas locales, para mejorar su eficacia y eficiencia.\n\nPara hacer posible estos objetivos y que puedan construirse las agendas urbanas en la provincia de Granada, hemos creado dos programas de Concertación específicos. Los Programas son:\n\n15422 Diseño de Agenda urbana 2030 para el desarrollo sostenible y el programa 15423 Asistencia técnica en la implementación inicial y consolidación de planes de acción de las agendas urbanas 2030\n\nLa intención es ampliar al conjunto de la provincia estos programas en el marco de la nueva concertación para el periodo 2022-2023. Incorporando al conjunto de los municipios, e incorporando dos Agendas urbanas importantes para el Conjunto de la Provincia; La Agenda Urbana del Área Metropolitana de Granada y la Agenda Urbana del conjunto de la Provincia como tal. Una agenda que tendrá la virtualidad de haberse construido de abajo arriba, e involucrando, haciendo participes a cientos de actores sociales y económicos que garantizan la calidad del proceso.\n\n- Diputación de Granada",
@@ -72,7 +80,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.transportes.gob.es/ferrocarriles/observatorios/observatorio-del-ferrocarril-en-espana"
+    "website": "https://www.transportes.gob.es/ferrocarriles/observatorios/observatorio-del-ferrocarril-en-espana",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Se <a href=\"https://www.omha.alcoi.org/wp-content/uploads/2022/03/TEXT-BOP-NUM-137-DE-220720-APROVACIO-DEFINITIVA.pdf\">constituye el 22-07-2020</a>, y a fecha de marzo de 2024 solo se ha reunido en <a href=\"https://www.omha.alcoi.org/es/actas/\">tres ocasiones</a>. Tras las elecciones municipales de 2023, parece que el OMHA no ha tenido ninguna actividad.",
@@ -257,7 +269,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://administracionelectronica.gob.es/pae_Home/pae_OBSAE.html"
+    "website": "https://administracionelectronica.gob.es/pae_Home/pae_OBSAE.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -270,7 +286,11 @@
     "parents": ["Ministerio de Igualdad", "Instituto de las Mujeres"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.inmujeres.gob.es/observatorios/observIgualdad/home.htm"
+    "website": "https://www.inmujeres.gob.es/observatorios/observIgualdad/home.htm",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Pretende ser un órgano técnico de análisis y diagnóstico de la situación de los y las jóvenes en nuestro país y de apoyo a la formulación de iniciativas, programas y políticas de juventud. Sus fines principales son: servir de cauce de participación de los jóvenes que viven en España mediante la expresión de sus opiniones sobre aquellos aspectos que les afectan; estudiar la realidad juvenil y las transformaciones que se van produciendo en la población joven; contribuir a la orientación y a la actualización de las políticas de juventud y de las actuaciones que desde las administraciones públicas y desde la sociedad se llevan a cabo dirigidas a la juventud; y analizar la imagen de los jóvenes en los medios de comunicación proponiendo medidas para mejorarla.\n\nElabora y difunde regularmente datos estadísticos, encuestas de opinión, estudios e investigaciones sobre la juventud y mantiene un fondo documental especializado que puede ser consultado a través de esta web o en su biblioteca.\n\nAdemás, edita periódicamente la Revista de Estudios de Juventud, en formato digital y en papel, en la que se abordan en profundidad y de manera monográfica, por parte de distintos expertos, los temas más relevantes relacionados con el ámbito juvenil.",
@@ -293,14 +313,22 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.injuve.es/observatorio"
+    "website": "https://www.injuve.es/observatorio",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Imagen de las Mujeres",
     "parents": ["Ministerio de Igualdad", "Instituto de las Mujeres"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.inmujeres.gob.es/observatorios/observImg/home.htm"
+    "website": "https://www.inmujeres.gob.es/observatorios/observImg/home.htm",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Cadena Alimentaria",
@@ -310,7 +338,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.mapa.gob.es/es/alimentacion/temas/observatorio-cadena/organizacion-y-estructura/"
+    "website": "https://www.mapa.gob.es/es/alimentacion/temas/observatorio-cadena/organizacion-y-estructura/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Es un proyecto de la Fundación Ibercivis en colaboración con la FECYT, que se dedica a recopilar proyectos de ciencia ciudadana en el país para fomentar la difusión y la colaboración entre científicos, gestores, y comunicadores. Su meta es facilitar el conocimiento sobre la ciencia ciudadana, considerando que es un campo en constante evolución. El observatorio también destaca por organizar eventos y recolectar recursos, habiendo iniciado su labor en 2016.",
@@ -323,7 +355,11 @@
     ],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://ciencia-ciudadana.es"
+    "website": "https://ciencia-ciudadana.es",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Gestión Empresarial en Biodiversidad"
@@ -413,7 +449,11 @@
         "name": "Los impactos de la minería en Andalucía Occidental"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio 2030",
@@ -434,7 +474,11 @@
         "name": "Ciudad y territorio en regeneración: Informe del Observatorio 2030 del CSCAE"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de Infancia del País Vasco",
@@ -479,14 +523,22 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.cultura.gob.es/cultura/libro/observatorio-de-la-lectura-y-el-libro/que-es-el-observatorio.html"
+    "website": "https://www.cultura.gob.es/cultura/libro/observatorio-de-la-lectura-y-el-libro/que-es-el-observatorio.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "observatorio.ocupacional@sepe.es",
     "name": "Observatorio de las Ocupaciones del Servicio Público de Empleo Estatal",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.sepe.es/HomeSepe/que-es-el-sepe/comunicacion-institucional/publicaciones/publicaciones-oficiales/listado-pub-mercado-trabajo/observatorio-ocupaciones.html"
+    "website": "https://www.sepe.es/HomeSepe/que-es-el-sepe/comunicacion-institucional/publicaciones/publicaciones-oficiales/listado-pub-mercado-trabajo/observatorio-ocupaciones.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "observatorio.museos@cultura.gob.es",
@@ -494,7 +546,11 @@
     "parents": ["Ministerio de Cultura"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.cultura.gob.es/observatorio-museos-espana/el-observatorio-de-museos-de-espana.html"
+    "website": "https://www.cultura.gob.es/observatorio-museos-espana/el-observatorio-de-museos-de-espana.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Publica informes de precios agrícolas y ganaderos.",
@@ -566,7 +622,11 @@
     ],
     "name": "Observatorio de Salud y Cambio Climático",
     "parents": ["Ministerio de Ciencia e Innovación"],
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Para <q>conocer la realidad de la juventud aragonesa desde un enfoque integral, con el fin de orientar las políticas de juventud adecuándolas a sus necesidades reales, así como plantear actuaciones eficaces dirigidas a dicho colectivo, lo que implica obtener información relevante, sistemática y actualizada, sobre la situación actual de los jóvenes aragoneses, así como su evolución a lo largo del tiempo y los principales factores que inciden en la misma</q>.",
@@ -642,7 +702,11 @@
     "parents": [
       "Ministerio de Transportes, Movilidad y Agenda Urbana",
       "Secretaría General de Transportes y Movilidad"
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -704,7 +768,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.rtve.es/observatorio-igualdad/"
+    "website": "https://www.rtve.es/observatorio-igualdad/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "tenerife@oficinarenovables.es",
@@ -786,7 +854,11 @@
     "parents": ["Ministerio de Sanidad"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://pnsd.sanidad.gob.es/profesionales/sistemasInformacion/home.htm"
+    "website": "https://pnsd.sanidad.gob.es/profesionales/sistemasInformacion/home.htm",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Empresarial de Navarra - Nafarroako Enpresen Behatokia",
@@ -826,7 +898,11 @@
     "parents": ["Ministerio de Inclusión, Seguridad Social y Migraciones"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.inclusion.gob.es/oberaxe/"
+    "website": "https://www.inclusion.gob.es/oberaxe/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Estatal de Condiciones de Trabajo",
@@ -845,7 +921,11 @@
   {
     "name": "Observatorio Estatal de la Convivencia Escolar",
     "scope": "estatal",
-    "website": "https://www.educacionyfp.gob.es/mc/sgctie/convivencia-escolar/observatorio.html"
+    "website": "https://www.educacionyfp.gob.es/mc/sgctie/convivencia-escolar/observatorio.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Nace con la finalidad de estructurar y desarrollar un dispositivo permanente de observación cooperativa y de evaluación participativa sobre la situación socio-económica del colectivo de las personas inmigrantes que residen en Asturias.",
@@ -1167,7 +1247,11 @@
     "is_active": "No",
     "name": "Observatorio Nacional 5G",
     "parents": ["Ministerio de Economía"],
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Iniciativa del Ayuntamiento de Valderredible con el Gobierno de Cantabria, planteada en 2021 y 2022. A fecha de la primavera de 2024 no consta que se haya puesto en marcha.",
@@ -1428,7 +1512,11 @@
     "parents": ["Ministerio de Ciencia, Innovación y Universidades"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.ciencia.gob.es/Secc-Servicios/Igualdad/OMCI.html"
+    "website": "https://www.ciencia.gob.es/Secc-Servicios/Igualdad/OMCI.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "from_date": "Mayo 2024",
@@ -1504,7 +1592,11 @@
     "parents": ["Cortes Generales"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatoriodelavidamilitar.es/"
+    "website": "https://www.observatoriodelavidamilitar.es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "A través del Observatorio pretendemos facilitar el acceso a la información y al conocimiento de todos los aspectos relacionados con el mundo de la vivienda, de manera que administraciones, empresas públicas y personales y cualquier interesado en este mundo estén en las mejores condiciones para adoptar decisiones eficaces y adaptadas a las necesidades del país. Del trabajo de unos y otros saldrá la información, estudios y trabajos que periódicamente verano a luz a través de esta web y de los boletines y publicaciones del Observatorio que estarán la disposición de los interesados en las diferentes secciones de este sitio.",
@@ -1617,7 +1709,11 @@
     "scope": "autonómico",
     "to_date": "Junio 2015",
     "type": "publico",
-    "website": "http://www.ideotalex.eu/"
+    "website": "http://www.ideotalex.eu/",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de la Igualdad",
@@ -1741,7 +1837,11 @@
       "Ministerio de Trabajo y Economía Social",
       "Instituto Universitario de Economía Social, Cooperativismo y Emprendimiento (Universidad de Valencia)"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Canario del Empleo (OBECAN)",
@@ -2141,7 +2241,11 @@
     "name": "Observatorio de Accesibilidad Web",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://administracionelectronica.gob.es/pae_Home/pae_Estrategias/pae_Accesibilidad/pae_Observatorio_de_Accesibilidad.html"
+    "website": "https://administracionelectronica.gob.es/pae_Home/pae_Estrategias/pae_Accesibilidad/pae_Observatorio_de_Accesibilidad.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Movilidad Metropolitana (OMM)",
@@ -2151,7 +2255,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.miteco.gob.es/es/calidad-y-evaluacion-ambiental/temas/movilidad/omm.html"
+    "website": "https://www.miteco.gob.es/es/calidad-y-evaluacion-ambiental/temas/movilidad/omm.html",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -2181,7 +2289,11 @@
       "Consejo de Gobierno de la Comunidad Autónoma de La Rioja"
     ],
     "scope": "estatal",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Economía Gallega",
@@ -2209,7 +2321,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.inclusion.gob.es/web/opi/estadisticas/observatorio_permanente_inmigracion"
+    "website": "https://www.inclusion.gob.es/web/opi/estadisticas/observatorio_permanente_inmigracion",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Observatorio impulsado por medio centenar de especialistas en ecología, con el objetivo de proporcionar nuevos datos y herramientas que ayuden a preservar la salud de los ríos y mitigar los efectos del cambio climático. Este observatorio constará de seis áreas de estudio que cubrirán las distintas zonas climáticas de la península ibérica –desde las zonas áridas del sur hasta la Cordillera Cantábrica-, en las cuales se hará un seguimiento anual para entender las dinámicas a largo plazo de los ecosistemas fluviales.\n\nCoordinado por la [Estación Biológica de Doñana (EBD)](https://ebd.csic.es/), perteneciente al Consejo Superior de Investigaciones Científicas (CSIC).",
@@ -2242,7 +2358,11 @@
       "Delegación del Gobierno contra la Violencia de Género"
     ],
     "scope": "estatal",
-    "website": "https://violenciagenero.igualdad.gob.es/instituciones/observatorioEstatal/home.htm"
+    "website": "https://violenciagenero.igualdad.gob.es/instituciones/observatorioEstatal/home.htm",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Innovación del Patrimonio Cultural de Galicia",
@@ -2299,7 +2419,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.airef.es/es/buscador-hallazgos/"
+    "website": "https://www.airef.es/es/buscador-hallazgos/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "location": "Alcalá de Henares",
@@ -2371,7 +2495,11 @@
     "parents": ["Ministerio de Industria y Turismo"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.mintur.gob.es/es-es/gabineteprensa/notasprensa/2024/paginas/20240430-observatorio-morosidad-privada.aspx"
+    "website": "https://www.mintur.gob.es/es-es/gabineteprensa/notasprensa/2024/paginas/20240430-observatorio-morosidad-privada.aspx",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Vasco de Vivienda",
@@ -2549,7 +2677,11 @@
     "from_date": "Septiembre de 2025",
     "to_date": "Se suprimió en 2014. En septiembre de 2025 se restableció.",
     "parents": ["Ministerio de Sanidad"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "Si",
@@ -2886,7 +3018,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.poderjudicial.es/cgpj/es/Temas/Violencia-domestica-y-de-genero/El-Observatorio-contra-la-violencia-domestica-y-de-genero/"
+    "website": "https://www.poderjudicial.es/cgpj/es/Temas/Violencia-domestica-y-de-genero/El-Observatorio-contra-la-violencia-domestica-y-de-genero/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Desde principios de 2014 comenzaron a evidenciarse en la Comunidad de Madrid las agresiones motivadas por LGTBIfobia. El Ministerio del Interior registró un aumento de más del 100% en este tipo de agresiones frente a las registradas en 2013. En dicho Informe se puso de manifiesto que los delitos de odio motivados por identidad de género y orientación sexual fueron los más numerosos, con un porcentaje del 40% sobre el total.\n\nExplicar las causas de la violencia motivada por LGTBIfobia es complicado y requiere un profundo análisis, pero uno de los principales factores es la mayor visibilidad en la sociedad de la diversidad sexual y de género. Leyes como la del Matrimonio Igualitario no sólo supusieron una concesión de derechos, sino que permitieron aspirar a la igualdad real como nunca antes, normalizando en las vidas cotidianas actitudes, expresiones de género o gestos de cariño que antes se evitaban en público. Desterrada la idea de «volver a los armarios», se debe continuar con la defensa de la visibilidad en todos y cada uno de los espacios en la calle y en todos y cada uno de los espacios públicos, hasta la completa desaparición de las actitudes discriminatorias y la violencia motivadas por LGTBIfobia.\n\nUn delito de odio por LGTBIfobia es una infracción penal en la que la víctima, el lugar o el objeto de la infracción se seleccionan por su conexión, relación, afiliación, apoyo o pertenencia real o supuesta a un grupo basado en la identidad de género y/o la orientación sexual. Como el resto de delitos de odio, reciben un tratamiento diferente a nivel legal ya que no sólo están motivados por un odio infundado hacia un grupo en sí sino que además busca crear una amenaza a todas las personas que pertenecen al grupo de la víctima y a su entorno. Una persona es la víctima, pero su entorno y las personas del grupo al que pertenece sufren una agresión en su conjunto.\n\nEl Observatorio Madrileño Contra la LGTBIfobia de Arcópoli, desde el inicio de su andadura en 2016, monitoriza, registra y denuncia los delitos de odio, las situaciones discriminatorias y cualquier otro incidente motivado por LGTBIfobia. Monitorizar y registrar es imprescindible para conocer la realidad a la que nos enfrentamos, ya que históricamente las personas LGTBI y las que han sido percibidas como tal han sufrido agresiones que caen en el olvido. Además, año tras año la Agencia Europea de Derechos Fundamentales mantiene el dato de que 9 de cada 10 víctimas no denuncian, por lo que es de vital importancia trabajar ese aspecto y ofrecer las herramientas y el acompañamiento necesario en la lucha contra todos esos casos en los que se ha atacado la dignidad de las personas.\n\nEl Observatorio Madrileño Contra la LGTBIfobia busca crear una red de trabajo efectivo en la lucha contra la LGTBIfobia en la Comunidad de Madrid y para ello cuenta con la inestimable colaboración de varias asociaciones e instituciones, así como de personas anónimas que de forma desinteresada ponen en nuestro conocimiento incidentes de los que tienen conocimiento, facilitando nuestra labor.",
@@ -2932,7 +3068,11 @@
     "parents": ["Puertos del Estado"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://observatorio.puertos.es/Paginas/Observatorio.aspx"
+    "website": "https://observatorio.puertos.es/Paginas/Observatorio.aspx",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Para <q>generar, analizar, reunir, organizar y comunicar información relevante y de calidad en el ámbito de la salud pública de Galicia, con el objetivo de proporcionar información basada en la evidencia científica, y ponerla a disposición de profesionales de la salud, de personal investigador, así como de la sociedad en general</q>.",
@@ -2960,7 +3100,11 @@
     "name": "Observatorio de la Sostenibilidad del Regadío",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.mapa.gob.es/es/desarrollo-rural/temas/gestion-sostenible-regadios/regadio-espanya/default_1.2.2.aspx"
+    "website": "https://www.mapa.gob.es/es/desarrollo-rural/temas/gestion-sostenible-regadios/regadio-espanya/default_1.2.2.aspx",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Rellenando un cuestionario de materias de Gobierno Abierto de el % de cumplimiento respecto a cada uno de los bloques y tu la posición de un municipio respecto a la media\n\nDiputación de Alicante",
@@ -3211,7 +3355,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatoriomargenes.es/wme/es/"
+    "website": "https://www.observatoriomargenes.es/wme/es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Profundizar <q>en el conocimiento sobre los sectores culturales y creativos, y sistematizar la información cuantitativa y cualitativa en el ámbito de la cultura y la creatividad en Navarra que ayude en la elaboración de las políticas culturales y la toma de decisiones, investigue en tendencias, conexiones con otros sectores, etc., identifique las buenas prácticas y experiencias que se desarrollan dentro y fuera de Navarra, y fomente el conocimiento de los públicos de la cultura y la creatividad</q>.",
@@ -3483,7 +3631,11 @@
       "- Comunidad de Madrid",
       "- Consejera de Familia, Juventud y Asuntos Sociales"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "description": "Busca suministrar información de todos los aspectos relativos al suelo empresarial, con el objetivo de que administraciones, empresas públicas y privadas, y cualquier persona interesada en este ámbito se encuentren en las condiciones idóneas para adoptar decisiones eficaces y adaptadas a las necesidades del país.",
@@ -3673,7 +3825,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatorioreligion.es"
+    "website": "https://www.observatorioreligion.es",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -3839,7 +3995,11 @@
     "parents": ["Ministerio de Transportes, Movilidad y Agenda Urbana"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://cibim.transportes.gob.es/observatorio-cibim"
+    "website": "https://cibim.transportes.gob.es/observatorio-cibim",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio de Contratación Pública es un lugar de encuentro para los profesionales de la materia desde el que proceder al debate y análisis de las novedades introducidas en su ordenación jurídica, así como para la realización de nuevas propuestas de actuación para la modernización de la contratación pública y materializar en la misma los principios de eficiencia, integridad y buena administración.",
@@ -3970,7 +4130,11 @@
       "Grupo Cooperativo Cajamar"
     ],
     "scope": "estatal",
-    "website": "https://www.boe.es/buscar/doc.php?id=BOE-A-2024-323"
+    "website": "https://www.boe.es/buscar/doc.php?id=BOE-A-2024-323",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El objetivo es la recogida sistemática de datos por medio de estadísticas desagregadas por sexos con el fin de conocer objetivamente la realidad específica de la igualdad de oportunidades entre mujeres y hombres en la Comunidad Autónoma del Principado de Asturias.\n\nInstituto Asturiano de la Mujer",
@@ -4136,7 +4300,11 @@
     "parents": ["Ministerio de Derecho Sociales y Agenda 2030"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatorioemancipacion.org/la-emancipacion-juvenil-en-espana-datos-generales/"
+    "website": "https://www.observatorioemancipacion.org/la-emancipacion-juvenil-en-espana-datos-generales/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -4240,7 +4408,11 @@
     "parents": ["Ministerio de Derechos Sociales Consumo y Agenda 2030"],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://minob.org/espanol/"
+    "website": "https://minob.org/espanol/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "OBAFI es un proyecto compartido entre la Dirección General de Juventud y Deportes de la JCCM y la UCLM, que pretende constituir una herramienta de utilidad pública para conocer los hábitos físico-deportivos y la condición física relacionada con la salud de los escolares castellano-manchegos.",
@@ -4800,7 +4972,11 @@
     "parents": [
       "Ministerio para la Transición Ecológica y el Reto Demográfico"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "movilidad@malaga.eu",
@@ -5308,7 +5484,11 @@
     "scope": "estatal",
     "from_date": "10 de agosto de 2024",
     "parents": ["Guardia Civil", "Ministerio del Interior"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "observatori@creama.org",
@@ -5336,7 +5516,11 @@
     "parents": [
       "Ministerio de Fomento (Dirección General de Transporte por Carretera)"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Acción de divulgación, análisis y sensibilización dirigido a mejorar el conocimiento sobre las desigualdades de género que se producen en el ámbito de empleo y emprendimiento y las claves para superarlas desde la corresponsabilidad de los distintos agentes que operan en el ámbito laboral.",
@@ -5348,7 +5532,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.observatorioigualdadyempleo.es/"
+    "website": "https://www.observatorioigualdadyempleo.es/",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "is_active": "None",
@@ -5647,7 +5835,11 @@
         "name": "Informe 1: Detección de noticias a través de aplicaciones de inteligencia artificial"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio sobre Drogas para Asturias es un centro que tiene como objetivo fundamental recoger, analizar y difundir indicadores que permitan evaluar la situación del consumo de drogas, sus repercusiones médicas, sociales y judiciales y la utilización de los servicios ofertados en este campo en Asturias.\n\nObservatorio de Salud en Asturias.",
@@ -5705,7 +5897,11 @@
     "parents": ["Ministerio de Defensa"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.defensa.gob.es/ministerio/organigrama/subdef/omi/"
+    "website": "https://www.defensa.gob.es/ministerio/organigrama/subdef/omi/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
@@ -5713,7 +5909,11 @@
     "parents": ["Ministerio de Agricultura, Pesca y Alimentación"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.mapa.gob.es/es/alimentacion/servicios/observatorio-de-precios-de-los-alimentos/estudios-e-informes/default.aspx"
+    "website": "https://www.mapa.gob.es/es/alimentacion/servicios/observatorio-de-precios-de-los-alimentos/estudios-e-informes/default.aspx",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
@@ -5733,7 +5933,11 @@
     "parents": ["Ministerio de Sanidad"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.aemps.gob.es/medicamentos-de-uso-humano/observatorio-de-uso-de-medicamentos/"
+    "website": "https://www.aemps.gob.es/medicamentos-de-uso-humano/observatorio-de-uso-de-medicamentos/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
@@ -5741,7 +5945,11 @@
     "parents": ["Ministerio de Derechos Sociales, Consumo y Agenda 2030"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.aesan.gob.es/AECOSAN/web/nutricion/seccion/observatorio.htm"
+    "website": "https://www.aesan.gob.es/AECOSAN/web/nutricion/seccion/observatorio.htm",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "sgfomon.sscc@mincotur.es",
@@ -5750,7 +5958,11 @@
     "parents": ["Ministerio de Economía, Comercio y Empresa"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://comercio.gob.es/ComercioInterior/Observatorio/Paginas/default.aspx"
+    "website": "https://comercio.gob.es/ComercioInterior/Observatorio/Paginas/default.aspx",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Aún no han creado su propia pagina pero su constitución aparece mencionada en varias páginas oficiales de la Junta de Andalucía, arriba uno de las noticias al respecto",
@@ -6565,7 +6777,11 @@
     "scope": "autonómico",
     "from_date": "2014. Creado por Decreto 132/2014 de la Junta de Andalucía",
     "parents": ["Junta de Andalucía"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "is_active": "Si",
@@ -7536,7 +7752,11 @@
       {
         "name": "Acuerdo a favor de la Responsabilidad Social Empresarial en Galicia"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Costeiro de la Xunta de Galicia",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -6652,5 +6652,274 @@
     "type": "mixto",
     "is_active": "No",
     "from_date": "Anunciado"
+  },
+  {
+    "name": "Observatorio para el Impulso Demográfico",
+    "description": "Observatorio/atlas de indicadores y mapas sobre demografía y territorio en la provincia de Huesca. <a href=\"https://www.dphuesca.es/observatorio-impulso-demografico\">Sitio web</a>.",
+    "parents": ["Diputación Provincial de Huesca"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dphuesca.es/observatorio-impulso-demografico"
+  },
+  {
+    "name": "Observatorio Provincial de Sostenibilidad de Albacete (OPSA)",
+    "description": "Plataforma provincial de indicadores de sostenibilidad (OPSA). <a href=\"https://observatoriosostenibilidad.dipualba.es/\">Sitio web</a>.",
+    "parents": ["Diputación de Albacete"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://observatoriosostenibilidad.dipualba.es/"
+  },
+  {
+    "name": "Observatorio de la Agenda Rural Sostenible de la provincia de Segovia",
+    "description": "Web/observatorio para el seguimiento de la Agenda Rural Sostenible de la provincia (indicadores y plan de acción). <a href=\"https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia\">Anuncio y enlace</a>.",
+    "parents": ["Diputación de Segovia"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia"
+  },
+  {
+    "name": "Observatori de la Qualitat de l'Aire del Camp de Tarragona (OQACT)",
+    "description": "Iniciativa/observatorio de calidad del aire en el Camp de Tarragona, con enfoque colaborativo y participación público-privada. <a href=\"https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/\">Fuente</a>.",
+    "parents": ["Institut Cerdà", "Repsol", "AEQT"],
+    "scope": "cataluna",
+    "type": "mixto",
+    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/"
+  },
+  {
+    "name": "OTIGRAN (Observatorio Turístico de Gran Canaria)",
+    "description": "Observatorio de innovación en turismo sostenible de Gran Canaria, con informes e indicadores para la toma de decisiones. <a href=\"https://observatorioturisticograncanaria.com/\">Sitio web</a>.",
+    "parents": ["Cabildo de Gran Canaria", "Turismo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://observatorioturisticograncanaria.com/"
+  },
+  {
+    "name": "Euskal Herriko Giza Eskubideen Behatokia (GEBEHATOKIA)",
+    "description": "Behatokia de derechos humanos (GEBEHATOKIA) publicado en el portal oficial del Gobierno Vasco. <a href=\"https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/\">Ficha</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/gobierno-vasco/-/asociacion/euskal-herriko-giza-eskubideen-behatokia-gebehatokia/"
+  },
+  {
+    "name": "Jokoaren Euskal Behatokia",
+    "description": "Observatorio vasco del juego/apuestas. <a href=\"https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/jokoaren-euskal-behatokia/"
+  },
+  {
+    "name": "Turismoaren Euskal Behatokia",
+    "description": "Observatorio vasco de turismo. <a href=\"https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/eusko-jaurlaritza/turismo-euskal-behatokia/"
+  },
+  {
+    "name": "Banda Zabal Ultralasterraren Euskal Behatokia",
+    "description": "Observatorio vasco de banda ancha ultrarrápida. <a href=\"https://www.euskadibandazabala.eus/index.php?idm=eu\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadibandazabala.eus/index.php?idm=eu"
+  },
+  {
+    "name": "Euskal Ekintzailetzaren Behatokia (Observatorio Vasco del Emprendimiento)",
+    "description": "Observatorio Vasco del Emprendimiento (Euskal Ekintzailetzaren Behatokia). <a href=\"https://eeb-ove.eus/observatorio/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco", "Universidad del País Vasco (UPV/EHU)"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://eeb-ove.eus/observatorio/"
+  },
+  {
+    "name": "Behatokia (Gizarte Aurreikuspen Osagarria)",
+    "description": "Behatokia sobre previsión social complementaria (Gizarte Aurreikuspen Osagarria). <a href=\"https://www.euskadi.eus/zer-da/web01-a2opsc/eu/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/zer-da/web01-a2opsc/eu/"
+  },
+  {
+    "name": "Observatorio de la calidad del aire (Terrassa)",
+    "description": "Observatorio municipal vinculado al seguimiento del plan de mejora de la calidad del aire. <a href=\"https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire\">Sitio web</a>.",
+    "parents": ["Ajuntament de Terrassa"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Terrassa (Barcelona)",
+    "website": "https://www.terrassa.cat/es/observatori-de-la-qualitat-de-l-aire"
+  },
+  {
+    "name": "Observatori de l'aigua (Terrassa)",
+    "description": "Mención al \"Observatori de l'aigua\" municipal en materiales/recursos educativos del Ayuntamiento. <a href=\"https://www.terrassa.cat/recursos-educatius\">Referencia</a>.",
+    "parents": ["Ajuntament de Terrassa"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Terrassa (Barcelona)",
+    "website": "https://www.terrassa.cat/recursos-educatius"
+  },
+  {
+    "name": "Observatori ambiental Litoral-Besòs",
+    "description": "Referencia municipal a un observatorio ambiental Litoral-Besòs como recurso externo sobre calidad del aire. <a href=\"https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire\">Enlace</a>.",
+    "scope": "cataluna",
+    "type": "publico",
+    "website": "https://www.sant-adria.cat/sant-adria-per-temes/medi-ambient/qualitat-de-laire/dades-en-linia-de-la-qualitat-de-laire"
+  },
+  {
+    "name": "Observatorio Valenciano de Salud",
+    "description": "Portal de indicadores de salud pública de la Generalitat Valenciana. <a href=\"https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud\">Sitio web</a>.",
+    "parents": ["Generalitat Valenciana"],
+    "scope": "comunidad_valenciana",
+    "type": "publico",
+    "website": "https://www.san.gva.es/es/web/salut-publica/observatorio-valenciano-de-salud"
+  },
+  {
+    "name": "Euskadiko Osasun Behatokia",
+    "description": "Observatorio de salud del País Vasco (Osasun behatokia). <a href=\"https://www.euskadi.eus/euskadiko-osasun-behatokia/\">Sitio web</a>.",
+    "parents": ["Gobierno Vasco"],
+    "scope": "pais_vasco",
+    "type": "publico",
+    "website": "https://www.euskadi.eus/euskadiko-osasun-behatokia/"
+  },
+  {
+    "name": "Observatorio Gallego de Salud Pública",
+    "description": "Observatorio de salud pública de Galicia (referencia en noticia sobre su lanzamiento). <a href=\"https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/\">Fuente</a>.",
+    "parents": ["Xunta de Galicia", "Consellería de Sanidade", "SERGAS"],
+    "scope": "galicia",
+    "type": "publico",
+    "website": "https://www.balidea.com/la-conselleria-de-sanidade-y-el-sergas-lanzan-el-observatorio-de-salud-publica-de-galicia-un-desarrollo-web-realizado-con-la-colaboracion-de-balidea/"
+  },
+  {
+    "name": "Observatorio Metropolitano de Transporte de Granada",
+    "description": "Anunciado en septiembre de 2025 como observatorio metropolitano de transporte/movilidad sostenible. <a href=\"https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html\">Fuente</a>.",
+    "scope": "andalucia",
+    "type": "publico",
+    "website": "https://www.europapress.es/esandalucia/granada/noticia-nace-observatorio-metropolitano-transporte-granada-marco-apuesta-movilidad-sostenible-20250916144741.html"
+  },
+  {
+    "name": "Observatorio de la Movilidad Metropolitana del CTAZ-USJ",
+    "description": "Observatorio/cuadro de mandos asociado al Consorcio de Transportes del Área de Zaragoza (CTAZ) y la Universidad San Jorge (USJ). <a href=\"https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/\">Acceso</a>.",
+    "parents": [
+      "Consorcio de Transportes del Área de Zaragoza (CTAZ)",
+      "Universidad San Jorge (USJ)"
+    ],
+    "scope": "aragon",
+    "type": "mixto",
+    "website": "https://observatoriomovilidad.ctaz.usj.es/cuadro-de-mandos/"
+  },
+  {
+    "name": "Observatorio para la Accesibilidad de Gran Canaria",
+    "description": "Observatorio para el seguimiento/impulso de la accesibilidad en Gran Canaria. <a href=\"https://www.grancanariaaccesible.info/observatorio/\">Sitio web</a>.",
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://www.grancanariaaccesible.info/observatorio/"
+  },
+  {
+    "name": "Observatorio del Comercio de Gran Canaria",
+    "description": "Observatorio/barómetro del comercio en Gran Canaria. <a href=\"https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/\">Sitio web</a>.",
+    "parents": ["Cámara de Comercio de Gran Canaria"],
+    "scope": "canarias",
+    "type": "mixto",
+    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/"
+  },
+  {
+    "name": "Observatorio de Prospectiva para la Gobernanza Insular",
+    "description": "Referencia a un observatorio de prospectiva para la gobernanza insular en documentación de seguimiento/evaluación del Cabildo. <a href=\"https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion\">Fuente</a>.",
+    "parents": ["Cabildo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion"
+  },
+  {
+    "name": "Observatorio de aves (Dunas de Maspalomas)",
+    "description": "Observatorio de aves en el ámbito de las Dunas de Maspalomas (espacio/instalación de observación). <a href=\"https://cabildo.grancanaria.com/dunas/observatorio-de-aves\">Sitio web</a>.",
+    "parents": ["Cabildo de Gran Canaria"],
+    "scope": "canarias",
+    "type": "publico",
+    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves"
+  },
+  {
+    "name": "Fundación Canaria Observatorio de Temisas",
+    "description": "Referencia a la Fundación Canaria Observatorio de Temisas en noticia de subvención del Cabildo (planetario). <a href=\"https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26\">Fuente</a>.",
+    "parents": [
+      "Fundación Canaria Observatorio de Temisas",
+      "Cabildo de Gran Canaria"
+    ],
+    "scope": "canarias",
+    "type": "mixto",
+    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26"
+  },
+  {
+    "name": "Observatorio de Datos Abiertos (Diputación de Castellón)",
+    "description": "Acción/entregable de Diputación de Castellón para la puesta en marcha de un Observatorio de Datos Abiertos. <a href=\"https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59\">Fuente</a>.",
+    "parents": ["Diputación de Castellón"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://gobiernoabierto.dipcas.es/es/sheets/public?area=4&id_accion=59"
+  },
+  {
+    "name": "Observatorio Urbano de la Agenda Urbana de Valverde de Burguillos",
+    "description": "Observatorio urbano asociado a la Agenda Urbana local para seguimiento/indicadores. <a href=\"https://agendaurbanavalverdeburguillos2030.badajoz.es/\">Sitio web</a>.",
+    "parents": ["Ayuntamiento de Valverde de Burguillos"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Valverde de Burguillos (Badajoz)",
+    "website": "https://agendaurbanavalverdeburguillos2030.badajoz.es/"
+  },
+  {
+    "name": "Observatorio ornitológico en Maderuelo",
+    "description": "Referencia a un observatorio ornitológico en el marco de actuaciones/planes provinciales. <a href=\"https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica\">Fuente</a>.",
+    "parents": ["Diputación de Segovia"],
+    "scope": "provincial",
+    "type": "publico",
+    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica"
+  },
+  {
+    "name": "Observatorio Local de Sostenibilidad de Albacete (OLSA)",
+    "description": "Referencia al Observatorio Local de Sostenibilidad de Albacete (OLSA) en información del OPSA. <a href=\"https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj\">Fuente</a>.",
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Albacete",
+    "website": "https://observatoriosostenibilidad.dipualba.es/web/noticias/post/OPSA-OLSA-bj"
+  },
+  {
+    "name": "Observatorio económico de la provincia de Sevilla",
+    "description": "Panel de indicadores económicos, desarrollado por el Colegio Profesional de Economistas de Sevilla con la colaboración/financiación de la Diputación de Sevilla y Prodetur. <a href=\"https://www.observatorioeconomicosevilla.com/\">Sitio web</a>.",
+    "parents": [
+      "Colegio Profesional de Economistas de Sevilla",
+      "Diputación de Sevilla",
+      "Prodetur"
+    ],
+    "scope": "provincial",
+    "type": "mixto",
+    "website": "https://www.observatorioeconomicosevilla.com/"
+  },
+  {
+    "name": "Indicadores de Administración Digital (Ayuntamiento de Madrid)",
+    "description": "Página municipal de indicadores de administración digital, presentada como instrumento de observación/seguimiento. <a href=\"https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Madrid"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Madrid",
+    "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Transformacion-Digital/Indicadores-de-Administracion-Digital/?vgnextchannel=98e57dae756be710VgnVCM2000001f4a900aRCRD&vgnextfmt=default"
+  },
+  {
+    "name": "Observatorio del Ruido (Algete)",
+    "description": "Referencia periodística a la reactivación del Observatorio del Ruido municipal. <a href=\"https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Algete"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Algete (Madrid)",
+    "website": "https://www.cronicanorte.es/el-psoe-de-algete-quiere-reactivar-el-observatorio-del-ruido/136624"
+  },
+  {
+    "name": "Observatorio de la Calidad del Aire (Algete)",
+    "description": "Referencia municipal a datos de un \"Observatorio de la Calidad del Aire\" en Algete. <a href=\"https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item\">Fuente</a>.",
+    "parents": ["Ayuntamiento de Algete"],
+    "scope": "municipal",
+    "type": "publico",
+    "location": "Algete (Madrid)",
+    "website": "https://www.aytoalgete.es/index.php?Itemid=455&id=263%3Aalgete-reduce-contaminantes-atmosfericos-confinamiento&option=com_k2&view=item"
   }
 ]

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -382,7 +382,11 @@
   },
   {
     "name": "Observatorio de la Infancia de España",
-    "website": "https://observatoriodelainfancia.mdsocialesa2030.gob.es/queEs/home.htm"
+    "website": "https://observatoriodelainfancia.mdsocialesa2030.gob.es/queEs/home.htm",
+    "coordinates": {
+      "lat": 39.3260685,
+      "lon": -4.8379791
+    }
   },
   {
     "name": "Observatorio de la Infancia de Andalucía",
@@ -690,7 +694,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://iberifier.eu/"
+    "website": "https://iberifier.eu/",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio del Transporte y la Logística en España",
@@ -790,7 +798,11 @@
     }
   },
   {
-    "name": "Observatorio Español contra la LGBTfobia"
+    "name": "Observatorio Español contra la LGBTfobia",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -805,14 +817,26 @@
     "scope": "autonómico",
     "type": "publico",
     "description": "Entidad de asesoramiento de la administración catalana y de concienciación de la sociedad en general en materia de paisaje.",
-    "website": "https://www.catpaisatge.net/ca"
+    "website": "https://www.catpaisatge.net/ca",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "name": "Observatorio Español de Acuicultura",
-    "website": "https://www.mapa.gob.es/es/pesca/temas/acuicultura/observatorio/"
+    "website": "https://www.mapa.gob.es/es/pesca/temas/acuicultura/observatorio/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
-    "name": "Observatorio Español de I+D+I (ICONO)"
+    "name": "Observatorio Español de I+D+I (ICONO)",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de Salud y Medio Ambiente de Andalucía",
@@ -834,7 +858,11 @@
     "from_date": "06/10/2025",
     "parents": [
       "Consellería de Presidencia, Xustiza e Deportes, Xunta de Galicia"
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Español de la Economía Social",
@@ -906,17 +934,29 @@
   },
   {
     "name": "Observatorio Estatal de Condiciones de Trabajo",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de Familia de la Ciudad de Orihuela",
     "scope": "local",
     "type": "publico",
-    "website": "https://www.orihuela.es/la-concejalia-de-familia-presenta-el-observatorio-de-familia-de-la-ciudad-de-orihuela/"
+    "website": "https://www.orihuela.es/la-concejalia-de-familia-presenta-el-observatorio-de-familia-de-la-ciudad-de-orihuela/",
+    "coordinates": {
+      "lat": 38.0856891,
+      "lon": -0.9448805
+    }
   },
   {
     "name": "Observatorio Estatal de Familias",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Estatal de la Convivencia Escolar",
@@ -963,15 +1003,27 @@
   },
   {
     "name": "Observatorio Estatal de la Dependencia",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Estatal de la Discapacidad",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Estatal de los Servicios Deportivos a las Administraciones Públicas",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Ambiental de Navarra - Nafarroako Ingurumen Behatokia",
@@ -1068,7 +1120,11 @@
     "scope": "autonómico",
     "to_date": "Actualmente sigue activo",
     "type": "publico",
-    "website": "https://eljusticiadearagon.es/oas/"
+    "website": "https://eljusticiadearagon.es/oas/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "name": "Observatorio de la Convivencia Escolar",
@@ -1148,7 +1204,11 @@
     "scope": "local",
     "to_date": "Continúa",
     "type": "publico",
-    "website": "https://www.alicante.es/es/contenidos/observatorio-municipal-vivienda-alquiler-alicante"
+    "website": "https://www.alicante.es/es/contenidos/observatorio-municipal-vivienda-alquiler-alicante",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "name": "Observatorio Galego de Acción Voluntaria",
@@ -1186,7 +1246,11 @@
       {
         "url": "https://cervantesobservatorio.fas.harvard.edu/es/informes"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Galego de Convivencia Escolar",
@@ -1363,7 +1427,11 @@
     "parents": ["Universidad Rey Juan Carlos"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.urjc.es/estudiar-en-la-urjc/vida-universitaria/4682-observatorio-para-el-analisis-y-visibilidad-de-la-exclusion-social"
+    "website": "https://www.urjc.es/estudiar-en-la-urjc/vida-universitaria/4682-observatorio-para-el-analisis-y-visibilidad-de-la-exclusion-social",
+    "coordinates": {
+      "lat": 40.416775,
+      "lon": -3.70379
+    }
   },
   {
     "name": "Observatorio Andaluz de Cultivos Frutales Exóticos",
@@ -1373,7 +1441,11 @@
     "scope": "autonómico",
     "parents": [
       "Consejería de Agricultura, Ganadería, Pesca y Desarrollo Sostenible de la Junta de Andalucía"
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "\n\nAyuntamiento de Gijón",
@@ -1427,18 +1499,34 @@
   },
   {
     "name": "Observatorio Nacional de las Telecomunicaciones y de la Sociedad de la Información",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Nacional de Seguridad Vial",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Nacional de Sequías e Inundaciones",
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
-    "name": "Observatorio Profesional del Instituto Nacional de las Cualificaciones"
+    "name": "Observatorio Profesional del Instituto Nacional de las Cualificaciones",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Integra, entre otros, los datos procedentes de los siguientes sistemas de información incluidos en el Plan de Calidad del Ayuntamiento de Alicant: Avisos de Incidencias; Oficina de Sugerencis y Reclamaciones; Redes Sociales y Web; Servicio Telefónica 010; Oficina de Atención Ciudadana (OAC); Solicitudes de Información\r\n(copia y pega de su página)\n\nAyuntamiento de Alicante",
@@ -1469,7 +1557,11 @@
   },
   {
     "name": "Observatorio Tecnológico",
-    "website": "http://educalab.es/intef/tecnologia/observatorio-tecnologico"
+    "website": "http://educalab.es/intef/tecnologia/observatorio-tecnologico",
+    "coordinates": {
+      "lat": 40.4455101,
+      "lon": -3.6546571
+    }
   },
   {
     "name": "Observatorio Urbano de Sevilla",
@@ -1524,7 +1616,11 @@
     "name": "Observatorio de la Producción Científica de la UA",
     "scope": "provincial",
     "type": "publico",
-    "website": "https://observatorio-cientifico.ua.es/"
+    "website": "https://observatorio-cientifico.ua.es/",
+    "coordinates": {
+      "lat": 38.3850684,
+      "lon": -0.5146732
+    }
   },
   {
     "name": "Observatorio de Prospectiva Tecnológica Industrial",
@@ -1532,7 +1628,11 @@
   },
   {
     "name": "Observatorio de formación en red Scopeo",
-    "website": "https://scopeo.usal.es"
+    "website": "https://scopeo.usal.es",
+    "coordinates": {
+      "lat": 40.970103,
+      "lon": -5.663539
+    }
   },
   {
     "name": "Observatorio da Mobilidade de Terras de Galicia",
@@ -1727,7 +1827,11 @@
       {
         "url": "https://www.uab.cat/doc/A75ServeIgualtatiDiversitat"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.5015527,
+      "lon": 2.1062607
+    }
   },
   {
     "name": "Observatorio del Mercado de Trabajo del Instituto Aragonés de Empleo",
@@ -1757,7 +1861,11 @@
     "parents": ["Red.es"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.ontsi.es/"
+    "website": "https://www.ontsi.es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio del Mercado de Trabajo del Servicio Público de Empleo del Principado de Asturias",
@@ -1809,7 +1917,11 @@
     "parents": [
       "Entidad Pública Empresarial Red.es, M.P.",
       "Universidad Nacional de Educación a Distancia (UNED)"
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de Empleo y Formación del Servicio Cántabro de Empleo",
@@ -1980,7 +2092,11 @@
     "website": "https://fundacionhermes.org/que-hacemos/proyectos/observatorio-de-los-derechos-digitales/",
     "scope": "estatal",
     "from_date": "5 de febrero de 2025",
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio para la Convivencia Escolar de Extremadura",
@@ -2182,7 +2298,11 @@
     "parents": ["Consejería de digitalización de la Comunidad de Madrid"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-competencias-digitales-comunidad-madrid"
+    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-competencias-digitales-comunidad-madrid",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "location": "A Coruña",
@@ -2299,7 +2419,11 @@
     "name": "Observatorio de la Economía Gallega",
     "type": "publico",
     "website": "https://www.conselleriadefacenda.gal/es_ES/areas-tematicas/patrimonio/estudos-e-estadisticas/operacions-e-actividades-estatisticas/observatorio-da-economia-galega",
-    "scope": "autonómico"
+    "scope": "autonómico",
+    "coordinates": {
+      "lat": 42.878213,
+      "lon": -8.544844
+    }
   },
   {
     "docs": [
@@ -2334,7 +2458,11 @@
     "name": "Observatorio Ibérico Fluvial",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://ebd.csic.es/"
+    "website": "https://ebd.csic.es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -2475,7 +2603,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.omau-malaga.com"
+    "website": "https://www.omau-malaga.com",
+    "coordinates": {
+      "lat": 36.7213028,
+      "lon": -4.4216366
+    }
   },
   {
     "name": "Observatorio Vasco del Emprendimiento",
@@ -2966,7 +3098,11 @@
     "parents": [
       "Consellería de Sanidade, el Servicio Galego de Saúde y la Universidade de Vigo"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.240598,
+      "lon": -8.720727
+    }
   },
   {
     "name": "Observatorio Municipal para la Transición hacia la Economía Circular de Andalucía",
@@ -2976,7 +3112,11 @@
     "scope": "autonómico",
     "from_date": "2017",
     "parents": ["Federación Andaluza de Municipios y Provincias"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "email": "estudis_prospectiva.daam@gencat.cat",
@@ -3057,7 +3197,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://contraelodio.org/wp/"
+    "website": "https://contraelodio.org/wp/",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "description": "Nace <q>para analizar las condiciones de competitividad en relación con los precios y calidad de los servicios portuarios, y acordar las variables de competitividad sobre las que establecer recomendaciones</q>.",
@@ -3454,14 +3598,22 @@
     ],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://www.oemv.es/"
+    "website": "https://www.oemv.es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
     "name": "Observatori Social, Ambiental i de Salut",
     "parents": ["Diputació de Girona"],
     "type": "publico",
-    "website": "https://observatori.dipsalut.cat/es"
+    "website": "https://observatori.dipsalut.cat/es",
+    "coordinates": {
+      "lat": 41.9794,
+      "lon": 2.821426
+    }
   },
   {
     "description": "Seguimiento periódico y exhaustivo de algunos elementos objetivables relacionados con el empleo y la vivienda que definen las condiciones de vida y los procesos de transición hacia la vida adulta de la población joven en España.",
@@ -3471,7 +3623,11 @@
     "parents": ["Consejo de la Juventud de España"],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://www.cje.org/observatorio-de-emancipacion/"
+    "website": "https://www.cje.org/observatorio-de-emancipacion/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
@@ -3504,7 +3660,11 @@
     "name": "Observatorio de la Criminalidad Organizada Transnacional",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://ocot.usal.es"
+    "website": "https://ocot.usal.es",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "None",
@@ -3591,7 +3751,11 @@
         "name": "Nada de nada"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "description": "Recolle e difunde información relacionada coa economía e fiscalidade local dos 313 concellos.",
@@ -3672,7 +3836,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.emasesa.com/comprometidos-contigo/observatorio-del-agua/"
+    "website": "https://www.emasesa.com/comprometidos-contigo/observatorio-del-agua/",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "description": "Para la elaboración de estudios sobre oportunidades, impacto y potencial industrial en Galicia.",
@@ -4264,7 +4432,11 @@
     "name": "Observatori Català de la Justícia en Violència Masclista",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://cejfe.gencat.cat/ca/observatori/"
+    "website": "https://cejfe.gencat.cat/ca/observatori/",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "name": "Observatorio Económico de la Provincia de Jaén",
@@ -4707,7 +4879,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/presentacio/"
+    "website": "https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/presentacio/",
+    "coordinates": {
+      "lat": 41.607695,
+      "lon": 2.28773
+    }
   },
   {
     "is_active": "None",
@@ -4718,7 +4894,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://observatorisalut.gencat.cat/ca/inici"
+    "website": "https://observatorisalut.gencat.cat/ca/inici",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio Tranformación y Participación es un órgano que se constituye para actuar como soporte a la docencia, a la investigación y la participación social. Asentado a nivel autonómico en Castilla y León pretende crear una Red Estatal que aporte soluciones desde la participación social al ámbito de la investigación e innovación aplicada.",
@@ -4754,19 +4934,31 @@
   },
   {
     "name": "Observatori del treball",
-    "website": "https://www.caib.es/sites/observatorideltreball/ca/portada-10648/"
+    "website": "https://www.caib.es/sites/observatorideltreball/ca/portada-10648/",
+    "coordinates": {
+      "lat": 39.5696,
+      "lon": 2.65016
+    }
   },
   {
     "name": "Observatorio do Emprego",
     "website": "https://conselleriaemprego.xunta.gal/formacion/cualificacions/observatorio-do-emprego",
     "description": "O servizo de Observatorio do Emprego é a unidade técnica para coñecer o funcionamento do mercado laboral, proporcionando información clave para o deseño das políticas de formación profesional.",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Ocupacional",
     "description": "Es la Unidad técnica encargada de la obtención y mantenimiento de un banco de datos para el conocimiento de las necesidades y evolución del mercado laboral, que pueda indicar en cada momento las directrices a seguir en materia de políticas activas de empleo y formación profesional en la Región de Murcia, para ello realizará, entre otras, las siguientes funciones:\n-Evaluar los datos que recibe de las distintas unidades y agentes relacionados con la formación y el empleo.\n-Recabar información de empresas y trabajadores para detectar las necesidades ocupacionales.\nExplotar los datos de las Oficinas de Empleo y de otros agentes para determinar las ocupaciones más demandadas.\n-Orientación y apoyo en el diseño de las políticas activas de empleo y formación.",
     "website": "https://sefcarm.es/web/pagina?IDCONTENIDO=70764&IDTIPO=100&RASTRO=c$m70720",
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Centro de Documentación Social de Navarra",
@@ -5078,7 +5270,11 @@
     "is_active": "None",
     "name": "Observatorio de la violencia de género",
     "scope": "estatal",
-    "website": "https://observatorioviolencia.org"
+    "website": "https://observatorioviolencia.org",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "No parece tener actividad. Para <q>identificar y servir de intercambio de información sobre experiencias participativas consideradas de un especial interés, tanto en Navarra como fuera de ella, para su divulgación y gestión de buenas y malas prácticas en esta materia. Asimismo, se pretende poner en marcha un seminario de personas expertas que coadyuven al desarrollo del Plan de Impulso de la Participación Ciudadana, así como la presentación de un proyecto innovador en esta materia</q>.",
@@ -5135,7 +5331,11 @@
     "name": "Observatorio Municipal para la Inclusión Social",
     "parents": ["Área de Derechos Sociales"],
     "type": "publico",
-    "website": "https://observatoriosocial.malaga.eu"
+    "website": "https://observatoriosocial.malaga.eu",
+    "coordinates": {
+      "lat": 36.721273,
+      "lon": -4.421399
+    }
   },
   {
     "description": "El Observatorio de la Realidad Social de Navarra evalúa políticas públicas y realiza análisis y prospección sobre la realidad social del territorio.",
@@ -5197,7 +5397,11 @@
       "Colegio Oficial de Pilotos de la Aviación Comercial"
     ],
     "scope": "estatal",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Regional de Mercado",
@@ -5346,7 +5550,11 @@
     "scope": "provincial",
     "to_date": "2027 (3 años de duración)",
     "type": "publico",
-    "website": "De momento no tiene, pero está vinculado con la Universidad de Zaragoza (https://ucc.unizar.es/)"
+    "website": "De momento no tiene, pero está vinculado con la Universidad de Zaragoza (https://ucc.unizar.es/)",
+    "coordinates": {
+      "lat": 41.648823,
+      "lon": -0.889085
+    }
   },
   {
     "docs": [
@@ -5380,7 +5588,11 @@
       "Diputación Foral de Bizkaia"
     ],
     "type": "publico",
-    "website": "https://bizkaikohirihondakinenbehatokia.com/es/observatorio-de-residuos/"
+    "website": "https://bizkaikohirihondakinenbehatokia.com/es/observatorio-de-residuos/",
+    "coordinates": {
+      "lat": 43.263012,
+      "lon": -2.934985
+    }
   },
   {
     "docs": [
@@ -5678,7 +5890,11 @@
     "parents": [
       "Instituto Galego de Estatística y la Comissão de Coordenação e Desenvolvimento Regional do Norte, a través de su Observatório das Dinâmicas Regionais, que cuenta con la colaboración del Instituto Nacional de Estatística de Portugal"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.8875172,
+      "lon": -8.5183692
+    }
   },
   {
     "is_active": "None",
@@ -5772,7 +5988,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://habitatge.gva.es/es/web/vivienda-y-calidad-en-la-edificacion/observatori-de-l-habitat-i-segregacio-urbana-de-la-cv"
+    "website": "https://habitatge.gva.es/es/web/vivienda-y-calidad-en-la-edificacion/observatori-de-l-habitat-i-segregacio-urbana-de-la-cv",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "Sí",
@@ -5888,7 +6108,11 @@
     "scope": "autonómico",
     "from_date": "14/5/2025",
     "parents": ["Generalitat Valenciana"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 39.469907,
+      "lon": -0.376288
+    }
   },
   {
     "email": "omigualdad@oc.mde.es",
@@ -6043,7 +6267,11 @@
     "parents": ["Ayuntamiento de Vitoria-Gasteiz"],
     "scope": "local",
     "type": "publico",
-    "url": "https://www.vitoria-gasteiz.org/wb021/was/contenidoAction.do?idioma=es&uid=u50993cf2_1781a8edc14__7e4c"
+    "url": "https://www.vitoria-gasteiz.org/wb021/was/contenidoAction.do?idioma=es&uid=u50993cf2_1781a8edc14__7e4c",
+    "coordinates": {
+      "lat": 42.846667,
+      "lon": -2.672778
+    }
   },
   {
     "description": "El Observatorio de Residuos Urbanos es un instrumento identificado como acción número 15 del vigente Plan de prevención y gestión de residuos urbanos de Araba-Álava, 2017-2030, abreviadamente PRU2030. <br> Es un instrumento de información, conocimiento y seguimiento permanente de aspectos relativos a la gestión de los residuos urbanos así como un punto de encuentro de todos los agentes interesados, favoreciendo la difusión de información técnica y académica sobre esta materia.",
@@ -6222,7 +6450,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://observass.com/"
+    "website": "https://observass.com/",
+    "coordinates": {
+      "lat": 43.361914,
+      "lon": -5.849389
+    }
   },
   {
     "description": "El Observatorio para la Convivencia Escolar de Cantabria es una organización colegiada de carácter consultivo que tiene como objetivo dotar a la administración educativa de las herramientas necesarias para la prevención y mejora del clima escolar en Cantabria.\n\nPresidencia: (Consejero de Educación, Formación Profesional y Universidades)\r\nVicepresidencia (Directora General de Centros e Infraestructuras Educativas)\r\nSecretario.\r\nVocales.",
@@ -6280,7 +6512,11 @@
     "scope": "autonómico",
     "to_date": "N/A",
     "type": "mixto",
-    "website": "https://www.oaib.es/observatorio-ciudadano/"
+    "website": "https://www.oaib.es/observatorio-ciudadano/",
+    "coordinates": {
+      "lat": 39.5696,
+      "lon": 2.65016
+    }
   },
   {
     "description": "El Observatorio Ciudadano de la Sequía es un proyecto de ciencia ciudadana que tiene por objetivo avanzar en el mejor conocimiento del riesgo de sequía en España.",
@@ -6289,7 +6525,11 @@
     "name": "Observatorio ciutadano de la Sequía",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.creaf.cat/es/observatorio-ciutadano-de-la-sequia"
+    "website": "https://www.creaf.cat/es/observatorio-ciutadano-de-la-sequia",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio del Cambio Climático en Aragón se configura como un espacio para la información, la investigación y la transferencia de conocimientos, dando cabida a todos aquellos aspectos ambientales, territoriales, sociales y económicos que de una u otra forma se pueden ver interferidos por el actual proceso de cambio climático antropogénico.\n\nSe crea con la vocación de recopilar toda la información científica que los distintos investigadores y grupos de investigación de la Comunidad Autónoma de Aragón han generado y generan sobre el cambio climático, su identificación, mitigación y adaptación, sin olvidar todos aquellos datos e informaciones que desde la gestión territorial u otros actores implicados en el tema puedan generarse. De esta forma, tanto en su función de repositorio de información científica como en aquella de enlace a los distintos organismos y colectivos implicados, este Observatorio ha de ser el punto de partida de cualquier iniciativa que surja de acción por el clima en nuestra Comunidad.\n\nSe trata, por tanto, de un instrumento colectivo al servicio de la Región, que permita construir y mantener una plataforma de información contrastada y veraz, para facilitar e impulsar la investigación y la elaboración de políticas y estrategias de mitigación, adaptación y concienciación sobre cambio climático en Aragón.\n\nDirección General de Cambio Climático y Educación Ambiental del Departamento de Agricultura, Ganadería y Medio Ambiente del Gobierno de Aragón: https://www.aragoncambioclimatico.es/politica-privacidad/",
@@ -6327,7 +6567,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://stomallorca.com"
+    "website": "https://stomallorca.com",
+    "coordinates": {
+      "lat": 39.5696,
+      "lon": 2.65016
+    }
   },
   {
     "description": "-eina de monitorització de la realitat i la competitivitat comarcal \r\n-Observatori de prospectiva i anàlisi de les megatendències de futur.\n\nAjuntament de Vic - Creacció\r\nAjuntament de Manlleu\r\nCambra d'Osona\r\nUVic\r\nCEDO",
@@ -6337,7 +6581,11 @@
     "name": "Observatori socioeconòmic d'Osona",
     "scope": "provincial",
     "type": "publico",
-    "website": "http://www.observatorisocioeconomicosona.cat/"
+    "website": "http://www.observatorisocioeconomicosona.cat/",
+    "coordinates": {
+      "lat": 41.930123,
+      "lon": 2.254862
+    }
   },
   {
     "description": "El objeto del Observatorio es el impulso de la presencia de las mujeres y de la igualdad de oportunidades en todas las manifestaciones culturales y en puestos de responsabilidad competencia del Ministerio de Cultura. Para cumplir este objetivo, el Observatorio analizará la información en materia de género para detectar situaciones de desigualdad y establecer medidas correctoras, propiciará la producción artística y la representación femenina en las distintas manifestaciones culturales, impulsará la elaboración de censos de expertas en igualdad de género y cultura, y promocionará el trabajo de las mujeres y su participación equilibrada en jurados y órganos de valoración.",
@@ -6358,7 +6606,11 @@
     "parents": ["Ministerio de cultura"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.cultura.gob.es/cultura/mc/espacio-de-igualdad/observatorio-igualdad-genero-cultura.html#"
+    "website": "https://www.cultura.gob.es/cultura/mc/espacio-de-igualdad/observatorio-igualdad-genero-cultura.html#",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Reducir la frecuencia y gravedad de los accidentes de tráfico e incrementar los medios y recursos destinados a la prevención de siniestros y a la atención de las víctimas",
@@ -6367,7 +6619,11 @@
     "parents": ["Servei Català de Trànsit"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://transit.gencat.cat/ca/seguretat_viaria/observatori/"
+    "website": "https://transit.gencat.cat/ca/seguretat_viaria/observatori/",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "description": "De acuerdo con el Decreto 81/2008, de 25 de julio, por el que se crea y regula el Observatorio del Trabajo de las Illes Balears, éste tiene como finalidad gestionar la obtención y la recopilación de los principales datos sociolaborales de las Illes Balears y profundizar en el estudio y la investigación de las características del empleo y el paro, así como de todos los aspectos relacionados con el mercado laboral (coste de trabajo, accidentes laborales, conflictos, condiciones y calidad de vida laborales, formación profesional e inserción laboral, seguridad y higiene en el trabajo, etc.)",
@@ -6446,7 +6702,11 @@
     "from_date": "19/10/2022",
     "parents": [
       "Alguna pista puede obtenerse de [esta noticia](https://planderecuperacion.gob.es/noticias/el-gobierno-y-las-comunidades-autonomas-acuerdan-poner-en-marcha-un-observatorio-de-buenas) donde se menciona que el gobierno y las comunidades autónomas lo pondrán en marcha y [este artículo del BOE](https://www.boe.es/buscar/act.php?id=BOE-A-2022-15818) donde se menciona que será gestionado por la Secretaría para la Unidad de Mercado y la nueva Conferencia Sectorial para la Mejora Regulatoria y el Clima de Negocios asume las funciones del Consejo para la Unidad de Mercado."
-    ]
+    ],
+    "coordinates": {
+      "lat": 43.6434392,
+      "lon": -7.6202751
+    }
   },
   {
     "email": "info@observatorigarrotxa.cat",
@@ -6454,14 +6714,22 @@
     "name": "Observatori per al Desenvolupament Sostenible de la Garrotxa",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.observatorigarrotxa.cat/"
+    "website": "https://www.observatorigarrotxa.cat/",
+    "coordinates": {
+      "lat": 42.182054,
+      "lon": 2.4889
+    }
   },
   {
     "is_active": "Si",
     "name": "Observatori del Partits Polítics de Catalunya",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.upf.edu/web/opcat"
+    "website": "https://www.upf.edu/web/opcat",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "docs": [
@@ -6473,7 +6741,11 @@
     "name": "Observatorio de la Producción Audidovisual",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.upf.edu/web/opa"
+    "website": "https://www.upf.edu/web/opa",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "name": "Observatorio Complutense de Desinformación",
@@ -6486,7 +6758,11 @@
       "Ministerio de Ciencia e Innovación",
       "Agencia Estatal de Investigación"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -6518,7 +6794,11 @@
     ],
     "scope": "estatal",
     "type": "mixto",
-    "website": "https://1mayo.ccoo.es/noticia:682134--CCOO_presenta_el_Observatorio_Social_de_las_personas_mayores_2023&opc_id=2910c4b71f6f452242c8bad8cf5f8f7e"
+    "website": "https://1mayo.ccoo.es/noticia:682134--CCOO_presenta_el_Observatorio_Social_de_las_personas_mayores_2023&opc_id=2910c4b71f6f452242c8bad8cf5f8f7e",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Procesar e difundir a información dispoñible sobre a sinistralidade laboral en Galicia, con propostas de mellora respecto á PRL e condicións de traballo.\r\nElaboración de documentación estatística derivada do tratamento dos datos que atanen á sinistralidade laboral, entendendo tanto accidentes de traballo como enfermidades profesionais e enfermidades relacionadas co traballo.\r\nElaboración de informes, documentos técnicos e estudos das distintas disciplinas preventivas en PRL, que a súa vez son o resultado do traballo do persoal técnico do ISSGA a través de programas executados polo propio Instituto. Isto tendo en conta os sucesivos mandatos tanto das estratexias galegas en materia de SST, como dos plans anuais de actividades do ISSGA.\r\nRealización de campañas, alertas e difusión de documentación técnica para a promoción da PRL e o mellor cumprimento da normativa.",
@@ -6567,7 +6847,11 @@
       {
         "url": "https://administracionelectronica.gob.es/pae_Home/pae_OBSAE/pae_Otras_fuentes/pae_CENATIC_OBSAE.html"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio de la realidad de las personas jóvenes es una herramienta fundamental para mantener un conocimiento actualizado de la realidad y poder plantear y ejecutar acciones que respondan a las necesidades y expectativas de las y los destinatarios de las políticas de juventud que materializa este Plan Joven.\n\nLos informes analizan diferentes ámbitos de la realidad, especialmente aquellos relacionados con la emancipación del colectivo joven: empleo, formación y vivienda, pero complementándolo con otros aspectos que ayudan en el camino de autonomía de las personas jóvenes: salud, actividad deportiva, euskera..",
@@ -6597,7 +6881,11 @@
     "parents": ["Ayuntamiento de Vitoria-Gasteiz"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.vitoria-gasteiz.org/wb021/was/contenidoAction.do?idioma=es&uid=u7538efd3_12da74c12a4__7fa5"
+    "website": "https://www.vitoria-gasteiz.org/wb021/was/contenidoAction.do?idioma=es&uid=u7538efd3_12da74c12a4__7fa5",
+    "coordinates": {
+      "lat": 42.846667,
+      "lon": -2.672778
+    }
   },
   {
     "description": "Se reúne después de 7 años en 2020.\r\nhttps://www.universidades.gob.es/el-observatorio-de-becas-se-reune-siete-anos-despues-para-abordar-la-reforma-del-sistema/",
@@ -6607,7 +6895,11 @@
     "parents": ["Min. Educación. Min. Universidades"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.boe.es/eli/es/rd/2010/10/01/1220/con"
+    "website": "https://www.boe.es/eli/es/rd/2010/10/01/1220/con",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "is_active": "Si",
@@ -6618,7 +6910,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.observatoriodeledadismo.es/"
+    "website": "https://www.observatoriodeledadismo.es/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El fin fundacional del OAG es garantizar que el puerto de Granadilla se construya y gestione de manera respetuosa con el medio ambiente, controlando el estado y las tendencias de la biodiversidad local y garantizando al mismo tiempo, la aplicación adecuada de las medidas correctores y compensatorias",
@@ -6648,7 +6944,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.easp.es/osp/"
+    "website": "https://www.easp.es/osp/",
+    "coordinates": {
+      "lat": 37.177336,
+      "lon": -3.598557
+    }
   },
   {
     "name": "El observatorio de Servicios Sociales",
@@ -6683,7 +6983,11 @@
     "parents": ["ANECA -> ministerio de universidades"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.aneca.es/web/guest/observatorio-de-la-calidad-del-sistema-espanol-de-universidades"
+    "website": "https://www.aneca.es/web/guest/observatorio-de-la-calidad-del-sistema-espanol-de-universidades",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "docs": [
@@ -6695,7 +6999,11 @@
     "name": "Observatorio de costes del transporte de mercancías (MINT)",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.transportes.gob.es/transporte-terrestre/servicios-al-transportista/observatorios-del-transporte/observatorios-del-transporte-de-mercancias-por-carretera/observatorios-costes-transporte-mercancias"
+    "website": "https://www.transportes.gob.es/transporte-terrestre/servicios-al-transportista/observatorios-del-transporte/observatorios-del-transporte-de-mercancias-por-carretera/observatorios-costes-transporte-mercancias",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "La misión de OPIMEC es “Coordinar, desarrollar y establecer desde Andalucía, como eje en España y el ámbito internacional, las estructuras básicas precisas para la creación y consolidación de una comunidad global en el campo de las enfermedades crónicas complejas y la pluripatología, mediante la búsqueda sistemática y selección rigurosa de innovaciones y contenidos de interés así como la promoción de la colaboración y el intercambio científico y técnico\".",
@@ -6704,7 +7012,11 @@
     "parents": ["Consejería de Salud y Consumo de la Junta de Andalucía"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.opimec.org/"
+    "website": "https://www.opimec.org/",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Consorcio de Infraestructuras de Investigación Europeas (EMSO ERIC).",
@@ -6712,7 +7024,11 @@
     "name": "Observatorio Europeo Multidisciplinar de los Fondos Marinos y de la Columna de Agua",
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.boe.es/eli/es/ai/2019/05/03/(1)"
+    "website": "https://www.boe.es/eli/es/ai/2019/05/03/(1)",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "De acuerdo con la Declaración Universal del derecho de los Animales que es aprobada por la Unesco el 27 de octubre de 1978 y ratificada posteriormente por las Naciones Unidas, los animales son seres vivos sensibles que tienen unos derechos que la especie humana tiene que respetar. Los animales de compañía son cada vez más variados, y en todas las legislaciones modernas se les otorga la consideración de un bien juridíco a proteger.\n\nEl Ayuntamiento tiene el deber de proteger a los animales, de acuerdo a las normas y principios constitucionales vigentes, sin prejuicio también de velar por la seguridad de las personas y de sus bienes. Por otra parte, es prioridad de este gobierno municipal aumentar la protección de los animales y aumentar la convivencia de estos con las personas.\n\nPor todo esto se ha creado el Observatorio de Protección Animal del ayuntamiento de Alcoy.",
@@ -6738,7 +7054,11 @@
     "parents": ["Ministerio de Ciencia e Innovación"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.actualidadjuridicaambiental.com/wp-content/uploads/2022/11/2022-OPAM.pdf"
+    "website": "https://www.actualidadjuridicaambiental.com/wp-content/uploads/2022/11/2022-OPAM.pdf",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "email": "info@contralalgtbifobia.es",
@@ -6746,7 +7066,11 @@
     "name": "Observatorio Valenciano contra la LGTBfobia",
     "scope": "autonómico",
     "type": "publico",
-    "website": "http://contralalgtbifobia.es/"
+    "website": "http://contralalgtbifobia.es/",
+    "coordinates": {
+      "lat": 39.469907,
+      "lon": -0.376288
+    }
   },
   {
     "docs": [
@@ -6758,7 +7082,11 @@
     "parents": ["Ministerio de Transportes, Movilidad y Agenda Urbana"],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://cpage.mpr.gob.es/producto/observatorio-hispano-frances-de-trafico-en-los-pirineos-11/"
+    "website": "https://cpage.mpr.gob.es/producto/observatorio-hispano-frances-de-trafico-en-los-pirineos-11/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "El Observatorio de Personas Tituladas es un proyecto del Consejo Social de la Universidade de Vigo creado con el propósito de que la universidad realice un seguimiento de las personas tituladas y coordine todo lo relativo al antiguo estudiantado.\n\nUniversidade de Vigo",
@@ -6767,7 +7095,11 @@
     "name": "Observatorio de Personas Tituladas de la Universidade de Vigo",
     "scope": "autonómico",
     "type": "publico",
-    "website": "http://observatorio.uvigo.gal/es/"
+    "website": "http://observatorio.uvigo.gal/es/",
+    "coordinates": {
+      "lat": 42.240598,
+      "lon": -8.720727
+    }
   },
   {
     "name": "Observatorio Andaluz de la Movilidad Sostenible y la Logística",
@@ -6890,7 +7222,11 @@
     "parents": ["Diputación de Gipuzkoa"],
     "scope": "gipuzkoa",
     "type": "publico",
-    "website": "https://www.ondavasca.com/nace-el-observatorio-turistico-de-gipuzkoa/"
+    "website": "https://www.ondavasca.com/nace-el-observatorio-turistico-de-gipuzkoa/",
+    "coordinates": {
+      "lat": 43.318334,
+      "lon": -1.981231
+    }
   },
   {
     "description": "La página municipal que explica este observatorio está caída en el momento en el que escribo esto…",
@@ -7003,7 +7339,11 @@
     "type": "mixto",
     "website": "https://webs.uab.cat/gret/es/2025/03/07/observatorio-de-competencias-digitales-y-empleabilidad/",
     "description": "Analizar el nivel de competencias digitales de la población y su relación con la empleabilidad en distintos sectores económicos, así como el impacto de la digitalización en el mercado de trabajo",
-    "parents": ["Universitat Autònoma de Barcelona", "IMANcorp Foundation"]
+    "parents": ["Universitat Autònoma de Barcelona", "IMANcorp Foundation"],
+    "coordinates": {
+      "lat": 41.5015527,
+      "lon": 2.1062607
+    }
   },
   {
     "description": "Para «abordar de manera conjunta y coordinada, con la participación de todo el sector rural y marino,\"el mayor desafío al que se enfrenta el sector\", ya que el relevo generacional supone traspasar de una manera progresiva el legado empresarial y familiar a una nueva generación en un momento, el actual, \"acuciado por la falta de rentabilidad, la inestabilidad y las amenazas que sufre el medio rural a novel global\"}",
@@ -7032,7 +7372,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "Si",
-    "description": "Es una biblioteca virtual de artículos, creados por docentes para docentes, en torno a la innovación digital en el aula. Cada artículo presenta una herramienta digital educativa, con su aplicación didáctica y metodológica, terminando con una valoración del autor/a y una recomendación final."
+    "description": "Es una biblioteca virtual de artículos, creados por docentes para docentes, en torno a la innovación digital en el aula. Cada artículo presenta una herramienta digital educativa, con su aplicación didáctica y metodológica, terminando con una valoración del autor/a y una recomendación final.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatori de la Inundabilitat de Catalunya",
@@ -7045,7 +7389,11 @@
       "Conselleria de Territori, Habitatge i Transició Ecològica",
       "Govern de Catalunya"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.387397,
+      "lon": 2.168568
+    }
   },
   {
     "name": "Observatorio de la Vivienda Turística",
@@ -7054,7 +7402,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "Si",
-    "description": "Anunciado por el presidente del Gobierno el 8 de octubre de 2025 con la finalidad de hacer <q>un atlas</q> de viviendas turísticas."
+    "description": "Anunciado por el presidente del Gobierno el 8 de octubre de 2025 con la finalidad de hacer <q>un atlas</q> de viviendas turísticas.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio ITE (Inspección Técnica de Edificios)",
@@ -7066,7 +7418,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "Si",
-    "description": "Presenta comparativas entre la información de los distintos municipios y comunidades, estadísticas de los datos facilitados por cada Ayuntamiento con respecto a las Inspecciones Técnicas de Edificios presentadas, e informes de coyuntura que muestren la evolución de dichos datos."
+    "description": "Presenta comparativas entre la información de los distintos municipios y comunidades, estadísticas de los datos facilitados por cada Ayuntamiento con respecto a las Inspecciones Técnicas de Edificios presentadas, e informes de coyuntura que muestren la evolución de dichos datos.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio del Emprendimiento (GEM)",
@@ -7075,7 +7431,11 @@
     "scope": "estatal",
     "type": "mixto",
     "is_active": "Si",
-    "description": "Para  la medición del fenómeno emprendedor con una perspectiva multidisciplinar que aplica conocimiento experto y metodologías exclusivas. Nuestra asociación está compuesta por una red de 200 investigadores, académicos y profesionales con una dilatada experiencia en el proceso emprendedor, los ecosistemas de emprendimiento y la formación a emprendedores."
+    "description": "Para  la medición del fenómeno emprendedor con una perspectiva multidisciplinar que aplica conocimiento experto y metodologías exclusivas. Nuestra asociación está compuesta por una red de 200 investigadores, académicos y profesionales con una dilatada experiencia en el proceso emprendedor, los ecosistemas de emprendimiento y la formación a emprendedores.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio municipal del árbol de Valencia - OMAV",
@@ -7116,7 +7476,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "Si",
-    "description": "Análisis detallado de flujos de transporte y comercio entre España y Portugal en 2019."
+    "description": "Análisis detallado de flujos de transporte y comercio entre España y Portugal en 2019.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de Ecodiseño",
@@ -7125,7 +7489,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "Si",
-    "description": "Espacio de referencia para la promoción del ECODISEÑO en el territorio de la EUROACE, de forma que actúe como punto de encuentro para los agentes del sector para potenciar la innovación y la transferencia de tecnología. El Observatorio de ECODISEÑO pretende facilitar servicios de información, orientación, asesoramiento, sistemas de vigilancia tecnológica, recopilación y seguimiento de las metodologías y tendencias del ECODISEÑO. En él podrás encontrar tendencias, artículos científicos, legislación, ayudas, buenas prácticas, etc., que te permitirán estar siempre actualizado en la temática."
+    "description": "Espacio de referencia para la promoción del ECODISEÑO en el territorio de la EUROACE, de forma que actúe como punto de encuentro para los agentes del sector para potenciar la innovación y la transferencia de tecnología. El Observatorio de ECODISEÑO pretende facilitar servicios de información, orientación, asesoramiento, sistemas de vigilancia tecnológica, recopilación y seguimiento de las metodologías y tendencias del ECODISEÑO. En él podrás encontrar tendencias, artículos científicos, legislación, ayudas, buenas prácticas, etc., que te permitirán estar siempre actualizado en la temática.",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de mercado de trabajo",
@@ -7237,7 +7605,11 @@
     "parents": ["Universidad Miguel Hernández"],
     "type": "publico",
     "email": "masculinidad@umh.es",
-    "from_date": "2013"
+    "from_date": "2013",
+    "coordinates": {
+      "lat": 38.2769777,
+      "lon": -0.6899447
+    }
   },
   {
     "description": "Creado por Decreto del Alcalde el <strong>29 de julio de 2022</strong> como órgano colegiado de seguimiento, asesoramiento y coordinación para evaluar el impacto de las violencias contra las mujeres en la ciudad de Madrid. Está adscrito al Área de Gobierno de Políticas Sociales, Familia e Igualdad y reúne a representantes municipales y de entidades sociales para analizar la realidad local, proponer medidas y medir el efecto de las políticas municipales (<a href=\"https://www.madrid.es/portales/munimadrid/es/Inicio/Igualdad-y-diversidad/Observatorio-Municipal-de-Violencia-contra-las-Mujeres/?vgnextfmt=default&amp;vgnextoid=67f723eab8248810VgnVCM1000001d4a900aRCRD&amp;vgnextchannel=c426c05098535510VgnVCM1000008a4a900aRCRD&amp;idCapitulo=11742639&amp;rm=dc9d8a7fd4c3b310VgnVCM2000000c205a0aRCRD\">portal municipal</a>). El pleno se convoca al menos dos veces al año y la comisión permanente celebra cuatro sesiones ordinarias anuales.",
@@ -7271,7 +7643,11 @@
     "scope": "estatal",
     "from_date": "2024",
     "parents": ["Universidad Politécnica de Valencia"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "description": "Órgano permanente de participación y evaluación creado en 2019 para implicar a la ciudadanía en el seguimiento de la gestión municipal de Madrid (<a href=\"https://diario.madrid.es/blog/notas-de-prensa/el-observatorio-de-la-ciudad-ya-tiene-49-vocales-elegidos-por-sorteo/#:~:text=12%2F03%2F2019\">constitución</a>). Su primera etapa contó con 49 vocales ciudadanos elegidos por sorteo que analizaban políticas municipales y elaboraban recomendaciones. En febrero de 2020 el observatorio se reestructuró como un órgano colegiado presidido por la Concejalía de Transparencia e integrado por responsables municipales para impulsar la evaluación institucional, la rendición de cuentas y la transparencia sobre los servicios públicos (<a href=\"https://www.lavanguardia.com/politica/20200228/473821415646/madrid-tiene-nuevo-observatorio-de-la-ciudad-sin-la-oposicion-ni-los-vecinos.html\">reforma 2020</a>). Publica informes periódicos de evaluación de la gestión municipal.",
@@ -7375,14 +7751,22 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Se ofrece un formulario de suscripción y el teléfono del ministerio es 915 977 000.",
-    "from_date": "Primer trimestre de 2012"
+    "from_date": "Primer trimestre de 2012",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio social del transporte por carretera",
     "type": "publico",
     "website": "https://www.transportes.gob.es/areas-de-actividad/transporte-terrestre/servicios-al-transportista/observatorio-social-del-transporte-por-carretera",
     "scope": "estatal",
-    "parents": ["Ministerio de transporte"]
+    "parents": ["Ministerio de transporte"],
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio de la Pobreza y Exclusión Social (OPEX)",
@@ -7402,7 +7786,11 @@
     ],
     "is_active": "Sí",
     "email": "eapn@eapn.es",
-    "from_date": "Principios de 2021"
+    "from_date": "Principios de 2021",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio para la Igualdad y la Diversidad",
@@ -7463,7 +7851,11 @@
       }
     ],
     "is_active": "Sí",
-    "email": "No disponible. Se ofrece un formulario de contacto general."
+    "email": "No disponible. Se ofrece un formulario de contacto general.",
+    "coordinates": {
+      "lat": 43.263012,
+      "lon": -2.934985
+    }
   },
   {
     "name": "Observatorio Extremeño de la Accesibilidad",
@@ -7505,7 +7897,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2003"
+    "from_date": "2003",
+    "coordinates": {
+      "lat": 43.263012,
+      "lon": -2.934985
+    }
   },
   {
     "name": "Observatorio de Competitividad de Bizkaia",
@@ -7529,7 +7925,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "2021"
+    "from_date": "2021",
+    "coordinates": {
+      "lat": 43.263012,
+      "lon": -2.934985
+    }
   },
   {
     "name": "Observatorio Vasco del Turismo",
@@ -7812,7 +8212,11 @@
     "type": "publico",
     "website": "https://gfw.diputacionalicante.es/Secretaria/Formularios/Observatorio",
     "is_active": "Sí",
-    "email": "No disponible"
+    "email": "No disponible",
+    "coordinates": {
+      "lat": 38.3436365,
+      "lon": -0.4881708
+    }
   },
   {
     "name": "Observatorio económico (Madrid)",
@@ -7961,7 +8365,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "Finales de 2022"
+    "from_date": "Finales de 2022",
+    "coordinates": {
+      "lat": 39.469907,
+      "lon": -0.376288
+    }
   },
   {
     "name": "Observatorio Turístico (Valladolid)",
@@ -8078,7 +8486,11 @@
     "scope": "estatal",
     "type": "publico",
     "is_active": "No",
-    "from_date": "2022-2023 (Compromiso de desarrollo)"
+    "from_date": "2022-2023 (Compromiso de desarrollo)",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio para la sostenibilidad turística local (Andalucía)",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -202,7 +202,11 @@
   },
   {
     "name": "Observatorio da Violencia no Contorno Laboral",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio Territorial de Estudios y Análisis (OTEA) de Granada es una entidad esencial para el desarrollo y la planificación estratégica de la provincia. Su función es apoyar a las entidades locales en la promoción económica y el desarrollo sostenible, proporcionando estudios técnicos y asistencia en la modernización de servicios públicos. Además, OTEA juega un papel crucial en el seguimiento de la evolución del empleo y los sectores productivos, así como en la difusión de buenas prácticas que pueden ser aplicadas en diferentes contextos, fortaleciendo así la gestión territorial y la economía circular.\n\n- Diputación de Granada",
@@ -346,7 +350,11 @@
   },
   {
     "name": "Observatorio de la Infancia de Andalucía",
-    "scope": "andalucia"
+    "scope": "andalucia",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Tiene como principal cometido el análisis del mercado laboral en nuestro municipio, tanto en lo referente a los/as demandantes de empleo, como sobre las contrataciones realizadas en las empresas del municipio.\n\nLos objetivos del Observatorio Local de Empleo de Fuenlabrada son:\n\nProfundizar en el conocimiento del mercado de trabajo de Fuenlabrada, identificando las necesidades de las empresas.\n\nConocer las características del perfil general de las personas desempleadas: sexo, edad, niveles formativos, población más afectada, tiempo de permanencia en el desempleo, grupos profesionales, etc.\n\nConocer las características de las contrataciones realizadas en Fuenlabrada: nº contratos, características, ubicación por sectores de actividad, características de las personas contratadas, etc… También de las afiliaciones a la seguridad social\n\nDifundir los principales resultados y estadísticas, a través de Informes y Estudios:\n\nAyuntamiento de Fuenlabrada",
@@ -370,7 +378,11 @@
   },
   {
     "name": "Observatorio de la Infancia de Cataluña / Observatori dels Drets dels Infants",
-    "scope": "cataluna"
+    "scope": "cataluna",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de Asturias",
@@ -426,15 +438,27 @@
   },
   {
     "name": "Observatorio de Infancia del País Vasco",
-    "scope": "pais_vasco"
+    "scope": "pais_vasco",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de Infancia de Cantabria",
-    "scope": "cantabria"
+    "scope": "cantabria",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "name": "Observatorio de la Infancia y la Adolescencia de les Illes Balears",
-    "scope": "islas_baleares"
+    "scope": "islas_baleares",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Para <q>analizar permanentemente la situación del libro, la lectura y las bibliotecas en su conjunto, tal y como se establece en la disposición adicional segunda de la Ley 10/2007, de 22 de junio, de la Lectura, el Libro y las Bibliotecas</q>.",
@@ -727,7 +751,11 @@
     "parents": ["Junta de Andalucía", "Consejería de Salud y Consumo"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.osman.es"
+    "website": "https://www.osman.es",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio do xogo",
@@ -917,7 +945,11 @@
     "parents": ["Diputación Provincial de Cáceres"],
     "scope": "provincial",
     "type": "publico",
-    "website": "http://observatorio.dip-caceres.es/"
+    "website": "http://observatorio.dip-caceres.es/",
+    "coordinates": {
+      "lat": 39.4745175,
+      "lon": -6.3716761
+    }
   },
   {
     "name": "Observatorio de la Comunidad de Castilla y León. Sección de Género",
@@ -972,31 +1004,55 @@
     "name": "Observatorio TransfomAcción y ParticipAcción",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.observatoriotransformacion.com"
+    "website": "https://www.observatoriotransformacion.com",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Regional de la Sociedad de la Información de Castilla y León (ORSI)",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.aytoburgos.es/-/observatorio-regional-de-la-sociedad-de-la-informacion-de-castilla-y-leon-orsi-"
+    "website": "https://www.aytoburgos.es/-/observatorio-regional-de-la-sociedad-de-la-informacion-de-castilla-y-leon-orsi-",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio de Agresiones",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.saludcastillayleon.es/profesionales/es/prevencion-riesgos-laborales/plan-integral-frente-agresiones/observatorio-agresiones"
+    "website": "https://www.saludcastillayleon.es/profesionales/es/prevencion-riesgos-laborales/plan-integral-frente-agresiones/observatorio-agresiones",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Galego Contra a Discriminación por Orientación Sexual e Identidade de Xénero",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Biodiversidade",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Violencia de Xénero",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "1. conocer, la situación del precio del mercado de alquiler libre en la ciudad.\n\nAyuntamiento de Alicante\n\nLa tarea la hace una consultora externa ( Factoría, Gestión y Consultoría, s.l.)",
@@ -1016,7 +1072,11 @@
   },
   {
     "name": "Observatorio Galego de Acción Voluntaria",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio de Datos Culturales de Barcelona es una iniciativa del Instituto de Cultura del Ayuntamiento de Barcelona que nació en 2015. La misión de este observatorio es elaborar y difundir datos, indicadores e informes sobre la realidad cultural de la ciudad, y poner toda la información al alcance de instituciones, agentes culturales, comunidad científica y público interesado de una manera ordenada y accesible, con el objetivo de ampliar y mejorar el conocimiento que tenemos sobre la vida cultural barcelonesa.",
@@ -1050,7 +1110,11 @@
   },
   {
     "name": "Observatorio Galego de Convivencia Escolar",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Startup de la Comunidad Valenciana",
@@ -1085,11 +1149,19 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Ofrece formulario de contacto.",
-    "from_date": "2016"
+    "from_date": "2016",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego de Educación Ambiental",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "is_active": "No",
@@ -1148,7 +1220,11 @@
     ],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/observatorio-vasco-cultura/"
+    "website": "https://www.euskadi.eus/observatorio-vasco-cultura/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "El Observatorio de I+d+I tiene como objetivo aunar toda la información de la actividad investigadora y de la innovación que se realiza en la universidad para que sea pública y accesible para la comunidad universitaria, el tejido empresarial y en general para cualquier usuario interesado en la producción científica que se realiza en la UPM y en los resultados generados.",
@@ -1335,7 +1411,11 @@
   },
   {
     "name": "Observatorio Territorial de Andalucía",
-    "scope": "andalucia"
+    "scope": "andalucia",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio para la Cibersociedad"
@@ -1368,11 +1448,19 @@
   },
   {
     "name": "Observatorio da Mobilidade de Terras de Galicia",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Galego da Xuventude",
-    "scope": "galicia"
+    "scope": "galicia",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio de costes de transportes de mercancías por carretera de Galicia",
@@ -1397,7 +1485,11 @@
     "parents": ["Consellería competente en materia de familia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "https://www.xunta.gal/dog/Publicados/2019/20190429/AnuncioG0425-150419-0001_gl.html"
+    "website": "https://www.xunta.gal/dog/Publicados/2019/20190429/AnuncioG0425-150419-0001_gl.html",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "a) Efectuar análisis y propuestas de actuación sobre el ejercicio de los derechos fundamentales y libertades públicas por los miembros de las Fuerzas Armadas.\r\nb) Elaborar, de oficio o a petición de parte, informes y estudios sobre el régimen de personal y las condiciones de vida en las Fuerzas Armadas.\r\nc) Proponer medidas que ayuden a la conciliación de la vida profesional, personal y familiar de los militares.\r\nd) Promover la adaptación del régimen del personal militar a los cambios que se operen en la sociedad y en la función pública.\r\ne) Analizar los problemas que en el entorno familiar de los afectados se producen como consecuencia de su disponibilidad, movilidad geográfica y de su específico ejercicio profesional que conlleva la participación en operaciones en el exterior.\r\nf) Evaluar la aportación adicional de recursos humanos a las Fuerzas Armadas a través de las diferentes modalidades de reservistas.\r\ng) Velar por la aplicación a los militares retirados de la normativa que ampara sus derechos pasivos y asistenciales y, en su caso, efectuar propuestas de mejora sobre ésta.\n\nSe compone de nueve personalidades de reconocido prestigio en el ámbito de la Defensa, recursos humanos o en derechos fundamentales y libertades públicas, elegidos cinco por el Congreso y cuatro por el Senado para un mandato de cinco años.",
@@ -1557,7 +1649,11 @@
         "name": "Memoria Anual del Observatorio del Mercado de Trabajo 2023",
         "url": "https://inaem.aragon.es/documents/51284/2219399/MEMORIA+OBSERVATORIO+2023.pdf/f21a07bc-6ee5-de35-3ad0-7ea943f00089?version=1.0&t=1711103605824&download=true"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "Si",
@@ -1668,7 +1764,11 @@
         "name": "Decreto de creación (referencia normativa citada en OBECAN)",
         "url": "http://www.gobiernodecanarias.org/boc/1998/160/003.html"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio Socioeconómico de la Provincia de Badajoz",
@@ -1830,7 +1930,11 @@
         "name": "Observatorio de la Cultura (AGCEX)",
         "url": "https://www.agcex.org/observatorio-de-la-cultura/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatori Ciutadà de la Biodiversitat",
@@ -1927,7 +2031,11 @@
         "name": "[1.La eInclusió a les Illes Balears, (2014).](https://www.fundaciobit.org/wp-content/uploads/2020/03/Informe-eInclusio-2014.pdf)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "La Xarxa d’Observatoris del Desenvolupament Econòmic Local (XODEL) és un espai on es\r\ngenera, es comparteix i es difon informació i on es fomenta el debat, la reflexió i l’intercanvi\r\nd’experiències entre els observatoris membres.\n\nLa Xarxa està composta de 21 observatoris i coordinada per l’Oficina Tècnica d’Estratègies per al\r\nDesenvolupament Econòmic de l’Àrea de Desenvolupament Econòmic i Turisme de la Diputació\r\nde Barcelona.\n\nLa Xarxa disposa d’una comunitat virtual (https://xodel.diba.cat), una eina de comunicació\r\nhoritzontal que permet al grup comunicar-se, treballar de manera col·laborativa i gestionar\r\nconeixement distribuït mitjançant diverses eines de participació.\n\nLa Xarxa està composta de 21 observatoris i coordinada per l’Oficina Tècnica d’Estratègies per al\r\nDesenvolupament Econòmic de l’Àrea de Desenvolupament Econòmic i Turisme de la Diputació\r\nde Barcelona\n\n**Observatoris**\n\n**_Observatoris municipals_**\n\n[Observatori de desenvolupament local de Badalona](http://www.badalona.cat/)\n\n[Observatori econòmic i social de Barberà del Vallès](https://www.bdv.cat/observatori-economic-i-social)\n\n[Departament d’estudis de la Gerència de política econòmica i desenvolupament local (Barcelona)](https://ajuntament.barcelona.cat/economiatreball/ca/documents)\n\n[Observatori socioeconòmic de l'Hospitalet de Llobregat](http://www.dinamitzaciolocallh.cat/)\n\n[Servei d’estratègia i governança (Mataró)](https://www.mataro.cat/ca/la-ciutat/observatori-de-ciutat)\n\n[Gabinet d’estudis i estadístiques (Rubí)](https://www.rubi.cat/ca/ajuntament/transparencia/observatoridelaciutat/gabinet-destudis-i-estadistiques)\n\n[Observatori de l’economia local (Sabadell)](http://www.vaporllonch.cat/observatori-economia-local)\n\n[Observatori socioeconòmic de Grameimpuls (Santa Coloma de Gramenet)](https://www.grameimpuls.cat/observatori/)\n\n[Servei d’estudis i Observatori de la ciutat (Terrassa) ](http://www.terrassa.cat/servei-estudis)\n\n**_Observatoris supramunicipals_**\n\n[Observatori del desenvolupament local de l'Alt Penedès i del Garraf](https://mancomunitat.cat/temes/banc-de-dades-socioeconomiques/)\n\n[Observatori socioeconòmic de l’Anoia](http://www.observatorianoia.cat/)\n\n[Observatori del Bages](https://www.manresa.cat/web/article/1006-informacio-socioeconomica)\n\n[Observatori comarcal del Baix Llobregat](http://www.elbaixllobregat.cat/observatori)\n\n[Observatori de desenvolupament local del Berguedà](http://www.adbergueda.cat/territori)\n\n[Observatori de desenvolupament local del Maresme](http://www.ccmaresme.cat/observatori)\n\n[Observatori Metropolità](https://agenciaeconomica.amb.cat/)\n\n[Observatori estratègic del Moianès](http://www.ccmoianes.cat/observatori/que-es-lobservatori-estrategic-del-moianes/)\n\n[Observatori socioeconòmic d’Osona](http://www.observatorisocioeconomicosona.cat/)\n\n[Observatori de la Riera de Caldes](http://www.rieradecaldes.com/observatori.html)\n\n[Observatori comarcal del Vallès Occidental](https://www.consellvallesoccidental.cat/observatori/)\n\n[L’Observatori – Centre d’estudis del Vallès Oriental](https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/)",
@@ -1960,7 +2068,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://xodel.diba.cat"
+    "website": "https://xodel.diba.cat",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "El Observatorio es el grupo de trabajo de la Comunidad de Madrid para la evaluación, el seguimiento y la propuesta de las acciones a realizar en el marco del Plan de Capacitación Digital para los Ciudadanos de la Comunidad de Madrid 2022-2025.\n\nCompetencias\r\na) Definir y perfeccionar el sistema de indicadores del Plan, elaborando planes de seguimiento trimestrales que permitan evaluar el desarrollo, resultado e impacto del plan.\r\nb) Difundir en la sociedad los contenidos y objetivos del Plan de Capacitación Digital para los Ciudadanos de la Comunidad de Madrid 2022-2025, y recoger las propuestas e iniciativas sociales que surjan en su desarrollo.\r\nc) Detectar cualquier desviación operativa y trasladar la información al grupo operativo para permitir la toma de decisiones basadas en las evidencias encontradas en los distintos informes de seguimiento.\r\nd) Fomentar la cooperación y colaboración en las actuaciones de las distintas consejerías en materia de desarrollo de competencias digitales para evitar solapamientos y duplicidades, proponiendo una solución a las consejerías implicadas en caso de que se produjeran intersecciones entre los colectivos en riesgo de exclusión social, sin perjuicio de las competencias atribuidas a cada una de ellas.\r\ne) Identificar nuevas propuestas y casos de éxito que puedan ser replicados en el ámbito del Plan.",
@@ -2217,7 +2329,11 @@
     "name": "Observatorio de Comercio del Gobierno Vasco",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "El OMAU desarrolla tres campos de trabajo. (1) Por una parte, realiza el seguimiento de indicadores medioambientales tanto de la ciudad de Málaga, como de las ciudades socias. En el caso de la Ciudad de Málaga los indicadores de seguimiento están directamente relacionados con la puesta en práctica en 2006 de la Agenda 21. Para el conjunto de los socios se emplea el Sistema Integrado de Indicadores Urbanos realizados junto a UN-HABITAT de Naciones Unidas, con un conjunto inicial de 37 indicadores.\n\nLos indicadores de seguimiento son un instrumento muy útil para confrontar situaciones ambientales urbanas en diferentes periodos de tiempo, para conocer y saber si avanzamos hacía los objetivos propuestos o tenemos problemas para alcanzar las metas establecidas en la Agenda 21. En algunos de los indicadores empleamos el soporte GIS para realizar el seguimiento periódico.\n\n(2) El OMAU es también un centro de intercambio de experiencias donde, de forma regular, se celebran conferencias o mesas redondas sobre temas de actualidad en el campo del Medio Ambiente Urbano. En 2004 y 2005 se celebraron los primeros cursos de formación, tanto presencial, como on line, que deben tener su continuidad anual, incorporando propuestas de trabajo o formatos novedosos que se realicen en otros ámbitos.\n\n(3) El Centro de Documentación del Programa URB-AL (CDPU) asienta su sede en el Observatorio, reforzando la biblioteca convencional y virtual que el OMAU dispone. El CDPU supone la concentración de toda la información desarrollada por el Programa URB-AL desde 1995, periodo en el que se desarrollaron 13 redes de ciudades que agruparon a 2.500 ciudades europeas y americanas. El CDPU ha recuperado los 192 proyectos URB-AL aprobados por la Comisión Europea, y que se desarrollaron entre 1998 y previsiblemente 2009. La Web del CDPU posibilita encontrar la documentación de los diferentes proyectos tanto a través de un buscador temático, como a través de su relación original con una determinada Red, funcionando a modo de biblioteca virtual de Buenas Practicas Urbanas.\n\nEn un principio es gestionado por dos funcionarios municipales, uno de ellos responsable del observatorio. Contrató 14 falsos autónomos cuyo despido fue anulado por el Tribunal Superior de Justicia y tuvieron que ser readmitidos.",
@@ -2242,7 +2358,11 @@
     "scope": "pais_vasco",
     "twitter": "@eeb_ove",
     "type": "publico",
-    "website": "https://eeb-ove.eus/inicio/"
+    "website": "https://eeb-ove.eus/inicio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "from_date": "30 abril 2024",
@@ -2257,34 +2377,54 @@
     "name": "Observatorio Vasco de Vivienda",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/observatoriovivienda/"
+    "website": "https://www.euskadi.eus/observatoriovivienda/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco del Juego",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-vasco-juego/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-vasco-juego/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio de Periodismo Machista",
     "scope": "pais_vasco",
     "twitter": "@pemachista",
     "type": "publico",
-    "website": "https://periodismomachista.com/"
+    "website": "https://periodismomachista.com/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco sobre Acoso y Discriminación",
     "scope": "pais_vasco",
     "twitter": "@ObservVascoAcos",
     "type": "publico",
-    "website": "https://www.observatoriovascosobreacoso.com/"
+    "website": "https://www.observatoriovascosobreacoso.com/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de la Juventud",
     "scope": "pais_vasco",
     "twitter": "@gaztebehatokia",
     "type": "publico",
-    "website": "https://www.gazteaukera.euskadi.eus/hasiera/"
+    "website": "https://www.gazteaukera.euskadi.eus/hasiera/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "OBITen",
@@ -2341,7 +2481,11 @@
     "name": "Observatorio de Coyuntura Industrial",
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.irekia.euskadi.eus/es/tags/observatoriodecoyunturaindustrial?uid=5196"
+    "website": "https://www.irekia.euskadi.eus/es/tags/observatoriodecoyunturaindustrial?uid=5196",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de Inmigración (Ikuspegi)",
@@ -2467,7 +2611,11 @@
     "scope": "pais_vasco",
     "twitter": "@BehatokiaLGTBI",
     "type": "publico",
-    "website": "https://lgtbi-behatokia.eus/"
+    "website": "https://lgtbi-behatokia.eus/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "docs": [
@@ -2558,7 +2706,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "website": "https://www.carm.es/web/pagina?IDCONTENIDO=5137&IDTIPO=11&RASTRO=c374$m5828",
-    "description": "La presente Orden tiene por objeto la creación del Observatorio Regional de la Discapacidad, cuya finalidad será la obtención y mantenimiento de la información necesaria para el conocimiento de las necesidades de las personas con discapacidad y el impacto de las actuaciones de los Sistemas de Protección Social sobre este colectivo. Asimismo, con este instrumento se pretende analizar y valorar la evolución de la discapacidad en la Región de Murcia, así como conocer los aspectos que se consideren importantes dentro de los citados Sistemas y la mejora de la calidad de vida de este colectivo"
+    "description": "La presente Orden tiene por objeto la creación del Observatorio Regional de la Discapacidad, cuya finalidad será la obtención y mantenimiento de la información necesaria para el conocimiento de las necesidades de las personas con discapacidad y el impacto de las actuaciones de los Sistemas de Protección Social sobre este colectivo. Asimismo, con este instrumento se pretende analizar y valorar la evolución de la discapacidad en la Región de Murcia, así como conocer los aspectos que se consideren importantes dentro de los citados Sistemas y la mejora de la calidad de vida de este colectivo",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "description": "El Observatorio Deportivo de Mallorca tiene el objetivo de fomentar una práctica deportiva responsable, unos hábitos saludables y la formación en torno a diferentes temas de actualidad deportiva.\n\nPlan de asesoramiento: formación y orientación dirigida a clubs, asociaciones de madres y padres de alumnos, federaciones deportivas, entrenadores...\r\nEls valors de l’esport: charlas impartidas por deportistas de alto nivel, que profundizan en los valores que aporta el ejercicio físico al desarrollo personal.",
@@ -2598,13 +2750,21 @@
     "name": "Observatorio de Igualdad",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-de-igualdad#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-de-igualdad#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Regional contra la Discriminación por Orientación Sexual e Identidad de Género",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Permanente Andaluz de las Migraciones (OPAM)",
@@ -2693,7 +2853,11 @@
     "parents": ["Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://agricultura.gencat.cat/ca/departament/estadistiques/observatori-agroalimentari-preus/"
+    "website": "https://agricultura.gencat.cat/ca/departament/estadistiques/observatori-agroalimentari-preus/",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Es <q>un instrumento de análisis y de actuación que, en el ámbito de la Administración de la Justicia, promueve iniciativas y medidas dirigidas a erradicar el problema social de la violencia doméstica y de género</q>.",
@@ -2888,7 +3052,11 @@
     "name": "Observatorio Ocupacional de la Universidad Miguel Hernández",
     "parents": ["Universidad Miguel Hernández"],
     "scope": "comunidad_valenciana",
-    "website": "https://observatorio.umh.es/"
+    "website": "https://observatorio.umh.es/",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Para <q>Constituir un instrumento de transparencia orientado a la investigación de la tributación local, la financiación a través de transferencias de otras administraciones, y en general, cualquier información de naturaleza económica con incidencia en el ámbito de la Administración Municipal</q>.",
@@ -2955,7 +3123,11 @@
     "parents": ["Xunta de Galicia"],
     "scope": "galicia",
     "type": "publico",
-    "website": "http://www.observatoriobiomasa.gal"
+    "website": "http://www.observatoriobiomasa.gal",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio de Precios de Canarias",
@@ -3052,7 +3224,11 @@
     ],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.culturanavarra.es/es/presentacion-8"
+    "website": "https://www.culturanavarra.es/es/presentacion-8",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "h) Publicar y difundir estudios, materiales y experiencias de educación para la convivencia y cultura de paz. i) Elaborar un informe anual sobre el estado de la convivencia y la conflictividad en los centros educativos, para lo que requerirá el apoyo informativo, documental y técnico de otras Administraciones Públicas con competencia en la materia y de los propios órganos y entidades de la Consejería competente en materia de educación, así como de entidades e instituciones privadas. j) Cualquier otra función de apoyo y asesoramiento vinculada a la recogida, análisis, difusión de la información y la investigación y la promoción de actuaciones en todas las materias relacionadas con la mejora de la convivencia en el ámbito de los centros educativos.",
@@ -3200,7 +3376,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.octsi.es/"
+    "website": "https://www.octsi.es/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -3361,7 +3541,11 @@
     "parents": ["EUSKALIT, Fundación Vasca para la Excelencia"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://www.euskalit.net/observatorio/es/"
+    "website": "https://www.euskalit.net/observatorio/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "L'Observatori del Programa Ajuntament+Sostenible fa anualment un seguiment per valorar com evoluciona la consecució de les dues directrius estratègiques del programa:\n\n[Seguiment de la contractació](http://www.ajsosteniblebcn.cat/ca/seguiment-de-la-contractacio_99538): s'elabora un Informe de seguiment de les instruccions tècniques per a l’aplicació de criteris de sostenibilitat de l'Ajuntament de Barcelona que recull els indicadors de seguiment dels diferents grups de productes i serveis, els principals plecs ambientalitzats cada any, així com els principals reptes i objectius de futur.\n\n[Seguiment de l'ambientalització interna](http://www.ajsosteniblebcn.cat/ca/seguiment-de-l-ambientalitzacio-interna_99544): s'elabora un Informe de seguiment de l'ambientalització interna de l'Ajuntament de Barcelona que recull com s'han impulsat els compromisos prioritaris per avançar envers la sostenibilitat interna recollits en set àmbits de treball, així com un recull de les bones pràctiques que han dut a terme gerències i organismes municipals de forma descentralitzada.",
@@ -7467,7 +7651,11 @@
     "parents": ["Diputación Provincial de Huesca"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dphuesca.es/observatorio-impulso-demografico"
+    "website": "https://www.dphuesca.es/observatorio-impulso-demografico",
+    "coordinates": {
+      "lat": 42.1360615,
+      "lon": -0.0298027
+    }
   },
   {
     "name": "Observatorio Provincial de Sostenibilidad de Albacete (OPSA)",
@@ -7669,7 +7857,11 @@
     "parents": ["Cabildo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion"
+    "website": "https://cabildo.grancanaria.com/pegip/seguimiento-y-evaluacion",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de aves (Dunas de Maspalomas)",
@@ -7677,7 +7869,11 @@
     "parents": ["Cabildo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves"
+    "website": "https://cabildo.grancanaria.com/dunas/observatorio-de-aves",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Fundación Canaria Observatorio de Temisas",
@@ -7688,7 +7884,11 @@
     ],
     "scope": "canarias",
     "type": "mixto",
-    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26"
+    "website": "https://cabildo.grancanaria.com/w/la-vicepresidencia-del-cabildo-de-gran-canaria-concede-una-subvenci%C3%B3n-de-60.000-euros-a-la-fundaci%C3%B3n-canaria-observatorio-de-temisas-para-la-construcci%C3%B3n-del-planetario-pino-ojeda?_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_viewSingleAsset=true&redirect=%2Frss%2Fnoticias%3Fp_p_id%3Dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu%26p_p_lifecycle%3D0%26p_p_state%3Dnormal%26p_p_mode%3Dview%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_delta%3D50%26p_r_p_resetCur%3Dfalse%26_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_kPMXGTcgkZuu_cur%3D26",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de Datos Abiertos (Diputación de Castellón)",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -3594,7 +3594,11 @@
       "Xunta de Galicia', 'Vicepresidencia Primera', 'Consellería de Economía, Empleo e Innovación', 'Consorcio Aeronáutico Gallego"
     ],
     "scope": "galicia",
-    "website": "https://www.consorcioaeronautico.com/observatorio-aeroespacial/gl/"
+    "website": "https://www.consorcioaeronautico.com/observatorio-aeroespacial/gl/",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "description": "El Observatorio tendrá como finalidad asesorar al Gobierno, formular planes de acción y programar actividades de conocimiento, intercambio y programación. Atendiendo a su finalidad, servirá de foro de diálogo permanente entre las distintas administraciones públicas y otras organizaciones representativas de intereses en el ámbito de la lusofonía, a fin de asegurar su participación activa en el abordaje de las relaciones de Galicia en dicho ámbito, así como aglutinará esfuerzos, coordinará las actuaciones público-privadas y procurará la consolidación en el tiempo de Galicia en el mundo de la lusofonía.",
@@ -3616,7 +3620,11 @@
       "Xunta de Galicia"
     ],
     "scope": "galicia",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "email": "ocj.dretssocials@gencat.cat",
@@ -3629,7 +3637,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/joventut/observatori_catala_de_la_joventut/index.html"
+    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/joventut/observatori_catala_de_la_joventut/index.html",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "docs": [
@@ -3643,7 +3655,11 @@
     "name": "Observatori Català de l’Esport",
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://inefc.gencat.cat/ca/inefc/projectes_institucionals/observatori-de-lesport/index.html"
+    "website": "https://inefc.gencat.cat/ca/inefc/projectes_institucionals/observatori-de-lesport/index.html",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "El Observatorio del pluralismo religioso en España aporta datos y diagnósticos sobre la diversidad de creencias y las necesidades vinculadas al ejercicio efectivo de la libertad religiosa para contribuir a la mejora de la gestión pública.",
@@ -3690,7 +3706,11 @@
     "parents": ["Gobierno de la Rioja"],
     "scope": "la_rioja",
     "type": "publico",
-    "website": "https://www.larioja.org/agricultura/es/estadistica-agraria/observatorio-precios-agrarios"
+    "website": "https://www.larioja.org/agricultura/es/estadistica-agraria/observatorio-precios-agrarios",
+    "coordinates": {
+      "lat": 42.2814642,
+      "lon": -2.482805
+    }
   },
   {
     "description": "objetivo es el impulso del despliegue de servicios de banda ancha por parte de operadores de telecomunicaciones. Esta convocatoria financia a operadores con hasta un 80% de subvención el despliegue de servicios de banda ancha de más de 300Mbps en zonas donde no existen servicios de banda ancha de más de 100Mbps. Cada operador presenta una solicitud única para cada una de las comunidades autónomas asignándose la ayuda para cada una de ellas al operador que mejor oferta presente.",
@@ -3745,7 +3765,11 @@
     "parents": ["Consejo de la Juventud"],
     "scope": "navarra",
     "type": "publico",
-    "website": "https://www.juventudnavarra.es/es/observatorio-joven"
+    "website": "https://www.juventudnavarra.es/es/observatorio-joven",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "Facilitar la acción intersectorial y comunitaria en salud, adaptando la información a cada contexto y cada uno de los sectores",
@@ -3880,7 +3904,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.observatoriodelainfancia.es/oia/esp/index.aspx"
+    "website": "https://www.observatoriodelainfancia.es/oia/esp/index.aspx",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "is_active": "None",
@@ -4377,7 +4405,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatori.smartcatalonia.gencat.cat/about"
+    "website": "https://observatori.smartcatalonia.gencat.cat/about",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Promover la innovación social y empresarial",
@@ -4542,7 +4574,11 @@
     "parents": ["Departament d'Empresa i Treball", "Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatoritreball.gencat.cat/ca/inici"
+    "website": "https://observatoritreball.gencat.cat/ca/inici",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatori del treball",
@@ -4604,7 +4640,11 @@
     "parents": ["Departament de Drets Socials", "Generalitat de Catalunya"],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/civisme_i_valors/observatori/"
+    "website": "https://dretssocials.gencat.cat/ca/ambits_tematics/civisme_i_valors/observatori/",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "docs": [
@@ -4618,7 +4658,11 @@
     "parents": ["Gobierno del Principado de Asturias", "Consejería de Salud"],
     "scope": "asturias",
     "type": "publico",
-    "website": "https://www.astursalud.es/noticias/-/noticias/omd"
+    "website": "https://www.astursalud.es/noticias/-/noticias/omd",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Centro educativo y divulgativo de Valencia para formar, concienciar y sensibilizar frente al cambio climático.",
@@ -4660,7 +4704,11 @@
       "Presidència. Telecomunicacions i transformació digital",
       "Generalitat de Catalunya"
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "Según el [DECRETO 150/2006, de 6 de octubre, del Consell, por el que se crea el Observatorio de Precios de los Productos Agroalimentarios de la Comunitat Valenciana](https://dogv.gva.es/es/resultat-dogv?signatura=2006/11596).",
@@ -4675,7 +4723,11 @@
     "name": "Observatorio de Precios de los Productos Agroalimetarios de la Comunitat Valenciana",
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://www.gva.es/es/inicio/atencion_ciudadano/buscadores/departamentos/detalle_departamentos?id_dept=14851"
+    "website": "https://www.gva.es/es/inicio/atencion_ciudadano/buscadores/departamentos/detalle_departamentos?id_dept=14851",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio de Sostenibilidad Urbana del Plan de Acción Local de la Agenda Urbana 2030 de Alcalá de Guadaíra",
@@ -4716,7 +4768,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://argos.gva.es/va/web/prospectiva/observatori"
+    "website": "https://argos.gva.es/va/web/prospectiva/observatori",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "email": "smn.obsam@cime.es",
@@ -4833,7 +4889,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://omc.cat"
+    "website": "https://omc.cat",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "description": "De este modo en el año 2005 surge el Observatorio de la Violencia de Género, donde diariamente recopilamos, a través de los medios de comunicación, y fuentes oficiales e institucionales relacionadas con la violencia de género, noticias, opiniones e informes que puedan ser de interés no sólo para profesionales en la materia, sino para la población en su conjunto.",
@@ -4885,7 +4945,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://brechadigital.gva.es"
+    "website": "https://brechadigital.gva.es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Realiza estudios e investigaciones encaminadas a mantener actualizado el Diagnóstico Social de la ciudad, entendiendo este, como un proceso permanente de análisis social de la ciudad, en el que se enmarcan todas las publicaciones.",
@@ -4936,7 +5000,11 @@
     ],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://isek.euskadi.eus/webisek00-isekquees/es/"
+    "website": "https://isek.euskadi.eus/webisek00-isekquees/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "docs": [
@@ -5061,7 +5129,11 @@
     ],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-regional-violencia-genero"
+    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-regional-violencia-genero",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "is_active": "None",
@@ -5151,7 +5223,11 @@
     ],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://obecan.es"
+    "website": "https://obecan.es",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "name": "Observatorio de Precios Agrarios de la Región de Murcia",
@@ -5218,7 +5294,11 @@
     ],
     "scope": "cataluna",
     "type": "publico",
-    "website": "https://observatorisalut.gencat.cat/ca/observatori_mort"
+    "website": "https://observatorisalut.gencat.cat/ca/observatori_mort",
+    "coordinates": {
+      "lat": 41.8523094,
+      "lon": 1.5745043
+    }
   },
   {
     "name": "Observatorio de Conducta Ética de la Guardia Civil",
@@ -5279,7 +5359,11 @@
     ],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-comunidad-madrid-victimas-del-delito"
+    "website": "https://www.comunidad.madrid/transparencia/unidad-organizativa-responsable/observatorio-comunidad-madrid-victimas-del-delito",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "is_active": "None",
@@ -5287,7 +5371,11 @@
     "parents": ["Comunidad de Madrid", "Consejería de Sanidad"],
     "scope": "comunidad_de_madrid",
     "type": "publico",
-    "website": "https://www.comunidad.madrid/servicios/salud/observatorio-resultados-servicio-madrileno-salud"
+    "website": "https://www.comunidad.madrid/servicios/salud/observatorio-resultados-servicio-madrileno-salud",
+    "coordinates": {
+      "lat": 40.5248319,
+      "lon": -3.7715628
+    }
   },
   {
     "description": "Proyecto transversal en el que participan las áreas de Deportes, Medio Ambiente, Turismo de Tenerife y Carreteras con el fin de ordenar y mejorar la situación del ciclismo en la Isla.\n\nCabildo de Tenerife",
@@ -5352,7 +5440,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://portalindustria.gva.es/es/observatorio-de-la-industria"
+    "website": "https://portalindustria.gva.es/es/observatorio-de-la-industria",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5360,7 +5452,11 @@
     "parents": ["Generalitat Valenciana", "Conselleria de Justicia e Interior"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://cjusticia.gva.es/es/web/processos-electorals/observatori-electoral"
+    "website": "https://cjusticia.gva.es/es/web/processos-electorals/observatori-electoral",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "description": "Para conocer un poco más sobre la historia de la Inteligencia Artificial, identificar a los agentes implicados y comenzar a manejarse con los términos más habituales empleados en este campo.",
@@ -5379,7 +5475,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://observatorioia.gva.es/es/"
+    "website": "https://observatorioia.gva.es/es/",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio transfronteirizo Galicia–Norte de Portugal",
@@ -5401,7 +5501,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://inclusio.gva.es/es/web/igualdad-diversidad/observatori-valencia-per-a-la-igualtat-de-trace-la-no-discriminacio-i-la-prevencio-dels-delictes-d-odi"
+    "website": "https://inclusio.gva.es/es/web/igualdad-diversidad/observatori-valencia-per-a-la-igualtat-de-trace-la-no-discriminacio-i-la-prevencio-dels-delictes-d-odi",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5412,7 +5516,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ceice.gva.es/es/web/inclusioeducativa/observatori-per-a-la-convivencia"
+    "website": "https://ceice.gva.es/es/web/inclusioeducativa/observatori-per-a-la-convivencia",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5423,7 +5531,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://brechadigital.gva.es/es"
+    "website": "https://brechadigital.gva.es/es",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5431,7 +5543,11 @@
     "parents": ["Generalitat Valenciana", "Consellería de Cultura y Deporte"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ovc.gva.es/es/observatori"
+    "website": "https://ovc.gva.es/es/observatori",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5442,7 +5558,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://ceice.gva.es/va/web/dg-trabajo/observatori-valencia-del-treball-decent"
+    "website": "https://ceice.gva.es/va/web/dg-trabajo/observatori-valencia-del-treball-decent",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "Sí",
@@ -5471,7 +5591,11 @@
     "name": "Observatorio de la Montaña de Aragón",
     "scope": "aragon",
     "type": "publico",
-    "website": "https://observatoriomontanaragon.com"
+    "website": "https://observatoriomontanaragon.com",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "is_active": "None",
@@ -5479,7 +5603,11 @@
     "parents": ["Agència Tributària Valenciana"],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://atv.gva.es/es/observatori-fiscal"
+    "website": "https://atv.gva.es/es/observatori-fiscal",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "email": "oasi@aragon.es",
@@ -5554,7 +5682,11 @@
     "parents": ["Hazi", "Gobierno Vasco"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://behatoki.eus"
+    "website": "https://behatoki.eus",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Valenciano de las familias",
@@ -5589,7 +5721,11 @@
     "parents": ["Gobierno de Navarra", "Departamento de Salud"],
     "scope": "navarra",
     "type": "publico",
-    "website": "http://www.nafarroa.gob.es/home_es/Temas/Portal+de+la+Salud/Ciudadania/Me+cuido/Al+final+de+la+vida/Observatorio+de+la+Muerte+Digna/"
+    "website": "http://www.nafarroa.gob.es/home_es/Temas/Portal+de+la+Salud/Ciudadania/Me+cuido/Al+final+de+la+vida/Observatorio+de+la+Muerte+Digna/",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "is_active": "None",
@@ -5634,14 +5770,22 @@
     "name": "Observatorio Regional Contra la Discriminación por Orientación Sexual e Identidad de Género",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0"
+    "website": "https://transparencia.carm.es/-/observatorio-regional-contra-la-discriminacion-por-orientacion-sexual-e-identidad-de-genero-en-la-comunidad-autonoma-de-la-region-de-murcia#gsc.tab=0",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "is_active": "None",
     "name": "Observatorio Virtual del Paisaje Mediterráneo",
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=9855&IDTIPO=246&RASTRO=c2195$m36284,36363"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=9855&IDTIPO=246&RASTRO=c2195$m36284,36363",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "docs": [
@@ -5663,7 +5807,11 @@
     ],
     "scope": "region_de_murcia",
     "type": "publico",
-    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=227&IDTIPO=200&__PLANT_PERSONALIZADA=/JSP/CARM/carm2018/organigramas/plantillaDetalleOrganigrama.jsp&IDESTRUCTURAJERARQUICA=473&RASTRO=c77$m5782"
+    "website": "https://www.carm.es/web/pagina?IDCONTENIDO=227&IDTIPO=200&__PLANT_PERSONALIZADA=/JSP/CARM/carm2018/organigramas/plantillaDetalleOrganigrama.jsp&IDESTRUCTURAJERARQUICA=473&RASTRO=c77$m5782",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "description": "El Observatorio de Convivencia es un conjunto de herramientas y mecanismos diversos y flexibles tanto para el análisis como para la búsqueda de respuestas a las necesidades de cohesión social de nuestra ciudad, que se adaptan a una realidad cada vez más diversa y cuya gestión resulta compleja.",
@@ -5693,7 +5841,11 @@
     "parents": ["Diputación Foral de Álava / Arabako Foru Aldundia"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://web.araba.eus/es/medio-ambiente/residuos/observatorio-de-residuos"
+    "website": "https://web.araba.eus/es/medio-ambiente/residuos/observatorio-de-residuos",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "description": "Para analizar y difundir información sobre la evolución de los indicadores relativos a la igualdad entre mujeres y hombres, para mejorar la planificación y evaluación de las políticas públicas desde la perspectiva de género.",
@@ -5707,7 +5859,11 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://observatori-igualtat.es/es/"
+    "website": "https://observatori-igualtat.es/es/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Órgano colegiado de carácter consultivo y de impulso al desarrollo de las políticas del Gobierno de Aragón de apoyo a las familias.\n\nObjetivos\r\n- Conocer, desde una perspectiva multisectorial, la situación, calidad de vida y demandas de las familias en Aragón.\r\n- Asesorar y realizar el seguimiento de la incidencia que sobre las familias aragonesas tienen las políticas públicas.\r\n- Promover mejoras sociales, económicas y legislativas que redunden en beneficio y apoyo de las familias aragonesas.\r\n- Estimular la investigación y el conocimiento de la realidad socio-económica de las familias en Aragón.\n\nGobierno de Aragón",
@@ -5936,7 +6092,11 @@
     "parents": ["Gobierno de Aragón"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragoncambioclimatico.es/observatorio/"
+    "website": "https://www.aragoncambioclimatico.es/observatorio/",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "STO Mallorca nace en el marco del [Plan de Recuperación, Transformación y Resiliencia del Gobierno de España](https://www.mincotur.gob.es/es-es/recuperacion-transformacion-resiliencia/paginas/plan-recuperacion-transformacion-resiliencia.aspx) con los fondos europeos Next Generation EU alineados con el plan estratégico de la FMT.\n\nEl Observatorio de Turismo Sostenible de Mallorca tiene como misión generar información de valor que permita guiar las decisiones del sector público y privado, dotando de inteligencia toda la cadena de valor de forma que se incrementa su competitividad y productividad, teniendo siempre en consideración los principios directores de la sostenibilidad.\n\nEl Observatorio de Turismo Sostenible de Mallorca tiene como misión generar información de valor que permita guiar las decisiones del sector público y privado, dotando de inteligencia toda la cadena de valor de forma que se incrementa su competitividad y productividad, teniendo siempre en consideración los principios directores de la sostenibilidad.\n\n- La Agencia de Estrategia Turística de las Islas Baleares (AETIB)\r\n- La Federación de Entidades Locales de las Islas Baleares (FELIB)\r\n- La Cámara de Comercio de Mallorca\r\n- AENA (Aeropuertos Españoles y Navegación Aérea)\r\n- La Autoridad Portuaria de Baleares (APB)\r\n- La Agencia Estatal de Meteorología (AEMET)\r\n- El Instituto de Estadística de las Illes Balears (IBESTAT)\r\n- Federación Empresarial Hotelera de Mallorca\r\n- Agrupación de Cadenas Hoteleras Baleares\r\n- Agrupación Empresarial de Agencias de Viaje de Baleares\r\n- Creado en 1905, Fomento del Turismo de Mallorca\r\n- La Fundación Impulsa Balears\r\n- El clúster internacional de las Tecnologías de la Información y la Comunicación aplicadas al Turismo (TURISTEC)\r\n- La Universitat de les Illes Balears (UIB)",
@@ -6059,7 +6219,11 @@
     "parents": ["Diputación de Cáceres"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://observatoriodipcc.dip-caceres.es/"
+    "website": "https://observatoriodipcc.dip-caceres.es/",
+    "coordinates": {
+      "lat": 39.4745175,
+      "lon": -6.3716761
+    }
   },
   {
     "name": "Observatorio de Buenas Prácticas Regulatorias",
@@ -6439,7 +6603,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dataraba.eus"
+    "website": "https://www.dataraba.eus",
+    "coordinates": {
+      "lat": 42.8440723,
+      "lon": -2.6820829
+    }
   },
   {
     "description": "Aquest projecte va néixer a la UIB l'any 2008 com a resultat del conveni de col·laboració entre el Govern Balear i la Universitat de les Illes Balears en matèria de serveis socials. Aquella primera etapa es va desenvolupar entre 2008 i 2012. Ara, en un context difícil de nou, la Universitat de les Illes Balears, a través de la Càtedra d’Innovació Social “la Caixa”, dóna un nou impuls a l'Observatori Social de les Illes Balears, amb l’objectiu de recollir i generar informació per millorar el coneixement de la situació social de Mallorca, Menorca, Eivissa i Formentera i detectar situacions emergents, punts crítics i respostes innovadores que facilitin la cohesió i la justícia social.",
@@ -6463,7 +6631,11 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://osib.uib.cat"
+    "website": "https://osib.uib.cat",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Anunciado el 4 de julio de 2024 sin más detalles. Enmarcado en una subvención de 150.000 € para el Programa de Segunda Oportunidad del Gobierno de Aragón.",
@@ -6475,7 +6647,11 @@
     ],
     "scope": "aragon",
     "type": "mixto",
-    "website": "https://www.aragonhoy.es/vicepresidencia-segunda-economia-empleo-industria/gobierno-aragon-sella-ata-upta-acuerdo-desarrollar-programa-segunda-oportunidad-96693"
+    "website": "https://www.aragonhoy.es/vicepresidencia-segunda-economia-empleo-industria/gobierno-aragon-sella-ata-upta-acuerdo-desarrollar-programa-segunda-oportunidad-96693",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Iniciativa de la Dirección General de Protección de Consumidores y &nbsp;Usuarios y de la Universidad de Zaragoza para, en el marco de las líneas de investigación ya consolidadas, dar un nuevo paso en el servicio a los consumidores aragoneses, integrando la información existente en las bases de datos del Centro de Información y Documentación Aragonés de Consumo (CIDAC) —señaladamente la información de prensa y los estudios realizados por otras entidades— y el Sistema de Información de Consumo —fundamentalmente los datos sobre consultas, reclamaciones y denuncias, campañas y arbitraje—, y completándola con información procedente de forma directa del consumidor — mediante encuestas.",
@@ -6533,27 +6709,47 @@
     ],
     "scope": "islas_baleares",
     "type": "publico",
-    "website": "https://www.caib.es/sites/objib/es/inici-33505/"
+    "website": "https://www.caib.es/sites/objib/es/inici-33505/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "name": "Observatorio Vasco del Comercio",
     "scope": "pais_vasco",
-    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio/"
+    "website": "https://www.euskadi.eus/gobierno-vasco/observatorio-comercio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de los Servicios Sociales",
     "scope": "pais_vasco",
-    "website": "https://www.behatuz.eus/es/"
+    "website": "https://www.behatuz.eus/es/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Vasco de la Cadena Alimentaria de Euskadi",
     "scope": "pais_vasco",
-    "website": "https://behatoki.eus/"
+    "website": "https://behatoki.eus/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Mujer Empresa",
     "scope": "pais_vasco",
-    "website": "https://www.aedbiz.org/observatorio-aed/"
+    "website": "https://www.aedbiz.org/observatorio-aed/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio y Consejo Social para el Reto Demográfico",
@@ -6761,7 +6957,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2019"
+    "from_date": "2019",
+    "coordinates": {
+      "lat": 37.9166355,
+      "lon": -1.4779797
+    }
   },
   {
     "name": "Observatorio Regional del Cambio Climático",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -479,7 +479,11 @@
     "parents": ["Consejeria de Agricultura y Pesca", "Junta de Andalucia"],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/agriculturaypesca/observatorio"
+    "website": "https://www.juntadeandalucia.es/agriculturaypesca/observatorio",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Su misión es <q>Generar información relevante y de calidad a políticos, gestores, investigadores, profesionales de la salud y a la sociedad civil en general con el fin de mejorar las políticas, programas y servicios sanitarios-sociosanitarios de forma que respondan equitativa y eficientemente a las necesidades de salud de la población y a la reducción de las desigualdades en salud en Cantabria</q>.",
@@ -582,7 +586,11 @@
     "parents": ["Instituto Aragonés de la Juventud"],
     "scope": "aragon",
     "type": "publico",
-    "website": "https://www.aragon.es/-/presentacion-1"
+    "website": "https://www.aragon.es/-/presentacion-1",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "IBERIFIER es un observatorio de medios digitales de España y Portugal, impulsado por la Comisión Europea y vinculado al [European Digital Media Observatory](https://edmo.eu/) (EDMO). Coordinado desde la Universidad de Navarra, está integrado por doce universidades, cinco organizaciones de verificación y agencias de noticias, y seis centros de investigación multidisciplinar.",
@@ -739,7 +747,11 @@
       "Instituto Universitario de Economía Social y Cooperativa",
       "Universidad de Valencia"
     ],
-    "website": "http://www.observatorioeconomiasocial.es"
+    "website": "http://www.observatorioeconomiasocial.es",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio Español de las Drogas y las Adicciones",
@@ -775,7 +787,11 @@
         "name": "Informe de tendencias en biotecnología"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio Español del Racismo y la Xenofobia",
@@ -874,7 +890,11 @@
         "name": "[Nº22 Abril-Junio 2022](https://www.navarra.es/documents/45973623/45979584/segundo+trimestre+2022.pdf/7a288214-2147-7736-c505-260ef7821f56?t=1734698990976)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "description": "El Observatorio Socioeconómico aporta la información necesaria para el diagnóstico a los procesos de planificación, facilitando indicadores de evolución socioeconómica al personal técnico que trabaja en desarrollo local.\n\n- Diputación Provincial de Cáceres",
@@ -914,7 +934,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Se ofrece un formulario de contacto.",
-    "from_date": "2014"
+    "from_date": "2014",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "description": "La función del observatorio es la investigación, análisis y desarrollo de soluciones para abordar el problema de la soledad en la región de Aragón.\n\nEl observatorio aragonés de la soledad está compuesto por los siguientes organismos:\n\nGobierno de Aragón\r\nFederación aragonesa de municipios, comarcas y provincias\r\nAyuntamiento de Zaragoza.\r\nConsejo aragonés de personas mayores.\r\nColegio profesional de trabajo social en Aragón.",
@@ -938,7 +962,11 @@
     "name": "Observatorio de la Convivencia Escolar",
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.educa.jcyl.es/convivenciaescolar/es/observatorio-convivencia-escolar"
+    "website": "https://www.educa.jcyl.es/convivenciaescolar/es/observatorio-convivencia-escolar",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio TransfomAcción y ParticipAcción",
@@ -997,7 +1025,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://barcelonadadescultura.bcn.cat/?lang=es"
+    "website": "https://barcelonadadescultura.bcn.cat/?lang=es",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Observatorio de la lengua española y las culturas hispánicas en los Estados Unidos",
@@ -1227,7 +1259,11 @@
     "parents": ["Ayuntamiento de Gijón"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.gijon.es/es/observatorio_empleo?observatorio=Sociedades%20Mercantiles%20constituidas"
+    "website": "https://www.gijon.es/es/observatorio_empleo?observatorio=Sociedades%20Mercantiles%20constituidas",
+    "coordinates": {
+      "lat": 43.5449422,
+      "lon": -5.66275
+    }
   },
   {
     "name": "Observatorio Nacional de las Telecomunicaciones y de la Sociedad de la Información",
@@ -1452,7 +1488,11 @@
   {
     "name": "Observatorio Argos de la Junta de Andalucía",
     "scope": "andalucia",
-    "website": "https://www.juntadeandalucia.es/servicioandaluzdeempleo/web/argos/web/es/ARGOS/index.html"
+    "website": "https://www.juntadeandalucia.es/servicioandaluzdeempleo/web/argos/web/es/ARGOS/index.html",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "OTALEX está financiado por el programa europeo INTERREGIII A y tiene marcado como objetivo estudiar y mostrar la realidad de un territorio, compuesto por las regiones del **Alentejo** en Portugal y **Extremadura** en España, separado convencionalmente por una frontera administrativa pero unido por sus características físicas, ambientales, sociales y económicas. Se trata de espacios rurales de baja densidad demográfica donde los recursos naturales, culturales y la calidad ambiental conforman sus atractivos fundamentales.\n\nLa IDE OTALEX es el resultado del esfuerzo, el compromiso y la colaboración entre instituciones a los dos lados de la frontera, con implicación de los tres niveles administrativos: Estatal, Regional y Local. Muestra los trabajos de homogeneización y estandarización de datos del territorio Alentejo-Extremeño, a través de clientes de visualización de mapas, consulta de topónimos y consulta de catálogo, dentro de las líneas de INSPIRE.\n\n- Gobierno de Extremadura (Ordenación del Territorio)\r\n- Diputación de Cáceres (Área de Desarrollo Local y Formación)\r\n- Diputación de Badajoz\r\n- Instituto Geográfico Nacional\r\n- Comunidade Intermunicipal do Alentejo Central\r\n- Comunidade Intermunicipal do Alto Alentejo\r\n- Direção-Geral do Território (PT)\r\n- Universidad de Extremadura\r\n- Comissão de Coordenação e Desenvolvimento Regional do Alentejo\r\n- Empresa de Desenvolvimento de Infra-estruturas do Alqueva, S.A\r\n- Univerisdade de Évora\r\n- Instituto Politécnico de Castelo Branco",
@@ -1548,7 +1588,11 @@
         "name": "Directorio de la red del Observatorio de las Ocupaciones — SEPE (Dirección Provincial de Asturias)",
         "url": "https://www.sepe.es/HomeSepe/que-es-el-sepe/que-es-observatorio/Directorio-red-Observatorio.html"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "El Observatorio Social Barcelona es un instrumento de conocimiento de la realidad social de la ciudad que tiene como objetivos principales: Conocer y evaluar la situación y la evolución de las condiciones de vida de la población, la realidad de los diferentes colectivos y la evolución de los fenómenos y procesos sociales que afectan a la calidad de vida de las personas y a la cohesión social de la ciudad. Difundir y compartir conocimiento con la ciudadanía, las entidades y asociaciones, y con el colectivo profesional y técnico, directivo y político. Apoyar a la planificación y a la toma de decisiones.",
@@ -1556,7 +1600,11 @@
     "parents": ["Ajuntament de Barcelona"],
     "scope": "local",
     "type": "publico",
-    "website": "https://ajuntament.barcelona.cat/dretssocials/es/content/observatorio-social-bcn"
+    "website": "https://ajuntament.barcelona.cat/dretssocials/es/content/observatorio-social-bcn",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Espacio de Observación de Inteligencia Artificial (IA) en español",
@@ -1665,7 +1713,11 @@
         "name": "https://ildefe.es/wp-content/uploads/2024/05/InformeMercadoLaboral_informecompleto1T24.pdf"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.5989995,
+      "lon": -5.5682413
+    }
   },
   {
     "name": "Observatorio del Sector TIC en Extremadura",
@@ -1703,7 +1755,11 @@
         "name": "[INFORME DE EVOLUCIÓN DE LA POLÍTICA AGRARIA COMÚN 2016](https://observatorioagrario.navarra.es/documents/30155142/31265379/Informe+PAC+2016-2019.pdf/eca94454-c936-2f21-304b-53279a5f4e51?t=1706606695550)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio FIEX de las Familias y la Infancia de Extremadura",
@@ -1784,7 +1840,11 @@
     "scope": "local",
     "from_date": "20/02/2025",
     "parents": ["Ajuntament de Reus"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 41.1555564,
+      "lon": 1.1076133
+    }
   },
   {
     "name": "Observatorio de Responsabilidad Social de Extremadura",
@@ -2353,7 +2413,11 @@
     "parents": ["Mercamadrid", "Ayuntamiento de Madrid"],
     "scope": "local",
     "type": "mixto",
-    "website": "https://www.mercamadrid.es/observatorio-tendencias-hosteleria/"
+    "website": "https://www.mercamadrid.es/observatorio-tendencias-hosteleria/",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
@@ -2564,7 +2628,11 @@
       {
         "name": "Informes anuales sobre la evolución del hecho inmigratorio desde los puntos de vista demográfico, económico-laboral, y de la opinión pública"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio de Innovación de Navarra - Nafarroako Berrikuntzaren Behatokia",
@@ -2592,7 +2660,11 @@
         "name": "Estudio evolutivo de la Encuesta FECYT en Navarra"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.7027944,
+      "lon": -1.7086231
+    }
   },
   {
     "name": "Observatorio de Igualdad del IIS Galicia Sur",
@@ -2781,7 +2853,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/cultura/flamenco/content/observatorio-del-flamenco"
+    "website": "https://www.juntadeandalucia.es/cultura/flamenco/content/observatorio-del-flamenco",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "Es un foro de debate, de análisis crítico, de reflexión y generador de propuestas de actuaciones para avanzar en un modelo de sociedad en el que la vivienda cumpla con las características que se recogen en la Nueva Agenda Urbana, un modelo de ciudad en que se facilite el acceso a una vivienda digna accesible, eficiente, sostenible y en el que quepamos por igual.",
@@ -2800,7 +2876,11 @@
     ],
     "scope": "cantabria",
     "to_date": "parece que en 2021 \"muere\"",
-    "website": "https://www.observatoriovivienda.cantabria.es"
+    "website": "https://www.observatoriovivienda.cantabria.es",
+    "coordinates": {
+      "lat": 43.1595664,
+      "lon": -4.0878382
+    }
   },
   {
     "description": "Para <q>aumentar el nivel de “empleabilidad” de nuestro estudiantado y colectivo <i>alumni</i></q>.",
@@ -2882,7 +2962,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/agp/sgt/temas/estadistica/CM-observatorio.html"
+    "website": "https://www.gobiernodecanarias.org/agp/sgt/temas/estadistica/CM-observatorio.html",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "Según su web\r\nLa promoción de iniciativas para contribuir al desarrollo sostenible del medio rural\r\nSensibilizar y dinamizar al población del medio rural y local sobre la capacidad de los territorios de establecer procesos autónomos de desarrollo y cambio a partir de los recursos y potencialidades endógena.\r\nParticipar apoyando activamente los procesos de desarrollo que se desarrollen en ámbitos locales y rurales.\r\nIntegrar diferentes áreas de conocimiento en el análisis y la intervención en el desarrollo local y rural.\r\nContribuir y promover procesos de planificación estratégica en ámbitos locales y rurales.\r\nPromover y mejorar la gobernanza en ámbitos locales y rurales.\n\nLo que se ve: Un par de informes y la estadística de datos de empleo, tomados de otras fuentes\n\nUniversidad de Murcia",
@@ -2897,7 +2981,11 @@
     "scope": "autonómico",
     "to_date": "Desde 2017 no se incluyen nuevos informes\r\nAparecen páginas con datos actualizados, pero parecen páginas zombis que funcionan solas",
     "type": "publico",
-    "website": "https://www.um.es/observalocal/"
+    "website": "https://www.um.es/observalocal/",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "description": "El Observatorio de la desigualdad se concibe para que Aragón pueda dotarse de herramientas adecuadas para generar indicadores estables de desigualdad en diversos ámbitos, que faciliten un análisis informado y nutran el debate social sobre estas cuestiones.",
@@ -2923,7 +3011,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.aragon.es/-/observatorio-de-desigualdad-de-aragon"
+    "website": "https://www.aragon.es/-/observatorio-de-desigualdad-de-aragon",
+    "coordinates": {
+      "lat": 41.3787291,
+      "lon": -0.7639373
+    }
   },
   {
     "description": "Tiene como objetivo <q>disponer de información para el seguimiento y el análisis de los márgenes empresariales y de mejorar el conocimiento sobre su evolución y sus implicaciones para el conjunto de la economía</q>.",
@@ -2991,7 +3083,11 @@
     ],
     "scope": "andalucia",
     "type": "publico",
-    "website": "https://www.juntadeandalucia.es/educacion/portals/web/convivencia-escolar/estructura-y-funcionamiento"
+    "website": "https://www.juntadeandalucia.es/educacion/portals/web/convivencia-escolar/estructura-y-funcionamiento",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "description": "El Observatorio del Sistema Penal y los Derechos Humanos (OSPDH) de la Universidad de Barcelona es un Centro de Investigación, creado en el mes de mayo de 2001, integrado por profesores/as universitarios de la UB y otras Universidades nacionales, de Europa y de América Latina, así como por profesionales de instituciones y organizaciones de defensa de derechos humanos, estudiantes avanzados de programas de postgrado y doctorados y activistas que se desempeñan en la lucha por la promoción de derechos y garantías básicas.",
@@ -3002,7 +3098,11 @@
     "parents": ["Universitat de Barcelona"],
     "scope": "barcelona",
     "type": "publico",
-    "website": "https://www.ub.edu/portal/web/observatori-sistema-penal/presentacio"
+    "website": "https://www.ub.edu/portal/web/observatori-sistema-penal/presentacio",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "description": "Promover, impulsar y apoyar el conocimiento de los mercados nacional e internacionales del vino y los productos vitivinícolas, en todos sus ámbitos y canales, incluyendo especificidades relativas a distribución y consumidores. Ver [Sobre nosotros](https://www.oemv.es/sobre-nosotros)\n\nMinisterio de Agricultura, Pesca y Alimentación\r\nICEX\r\nFederación Española del Vino",
@@ -3055,7 +3155,11 @@
     "parents": ["Gobierno de Canarias"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.gobiernodecanarias.org/economia/ocea/"
+    "website": "https://www.gobiernodecanarias.org/economia/ocea/",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "is_active": "None",
@@ -5354,7 +5458,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://obsaludasturias.com/obsa"
+    "website": "https://obsaludasturias.com/obsa",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "El Observatorio de la Calidad de Tenerife es una iniciativa del Cabildo Insular, orientada al estudio, análisis y evolución de las nuevas tendencias y modelos de calidad de gestión en el ámbito nacional e internacional, dirigida especialmente a monitorizar y fomentar la implantación de la calidad en Tenerife.\n\nCabildo de Tenerife",
@@ -5363,7 +5471,11 @@
     "parents": ["Cabildo de Tenerife"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.calidadtenerife.org"
+    "website": "https://www.calidadtenerife.org",
+    "coordinates": {
+      "lat": 28.2935785,
+      "lon": -16.6214471
+    }
   },
   {
     "description": "El Observatorio de la Publicidad e Información no Sexista nace para recoger todas aquellas quejas o denuncias que puedan atentar contra la imagen o dignidad de las mujeres en medios de comunicación y/o publicitarios.\n\nInstituto Asturiano de la Mujer.",
@@ -5390,7 +5502,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://iam.asturias.es/observatorio-de-la-publicidad-e-informacion-no-sexista"
+    "website": "https://iam.asturias.es/observatorio-de-la-publicidad-e-informacion-no-sexista",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "description": "Sistema de información que permita la adecuada dirección, planificación y evaluación de los servicios sociales.\n\nLa creación del Observatorio Asturiano de Servicios Sociales tiene la finalidad de:\r\n-Aportar y analizar información que permita un mejor conocimiento de la situación de los servicios sociales del Principado de Asturias con el fin favorecer la toma de decisiones en el diseño y desarrollo de políticas sociales.\r\n-Asesorar a la Dirección General con competencia en materia de planificación de servicios sociales en el ejercicio de sus funciones como unidad estadística.\r\n-Facilitar la labor a profesionales del ámbito técnico y/o científico relacionados con los servicios sociales.\r\n-Materializar el derecho que tiene la ciudadanía de acceso a la información que obra en poder de la Administración sobre los servicios que presta y de su impacto en la sociedad.\n\nSe organiza en un Consejo Rector y una Comisión Asesora cuya composición se detalla en el [Decreto 35/2017, de 31 de mayo, por el que se crea y se regula el Observatorio Asturiano de Servicios Sociales (OBSERVASS)], BOPA 132 de 9-vi-2017 (https://sede.asturias.es/bopa/2017/06/09/2017-06449.pdf)",
@@ -6124,7 +6240,11 @@
     "parents": ["Diputación Provincial de Zaragoza", "Universidad de Zaragoza"],
     "scope": "provincial",
     "type": "mixto",
-    "website": "https://ocatcodes.unizar.es"
+    "website": "https://ocatcodes.unizar.es",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Observatorio de Competencias Digitales y Empleabilidad",
@@ -6220,7 +6340,11 @@
     "website": "https://www.xunta.gal/es/notas-de-prensa/-/nova/007512/xunta-adjudica-nuevo-observatorio-sostenibilidad-turistica-que-permitira-monitorizar",
     "scope": "autonómico",
     "from_date": "22 de noviembre de 2024",
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio Transfronterizo España-Portugal",
@@ -6299,7 +6423,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2020"
+    "from_date": "2020",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio Regional de Discapacidad",
@@ -6316,7 +6444,11 @@
     "scope": "region_de_murcia",
     "type": "publico",
     "is_active": "Si",
-    "from_date": "2009"
+    "from_date": "2009",
+    "coordinates": {
+      "lat": 37.9923795,
+      "lon": -1.1305431
+    }
   },
   {
     "name": "Observatorio de las Masculinidades",
@@ -6523,7 +6655,11 @@
       }
     ],
     "is_active": "Sí",
-    "email": "info@faen.es"
+    "email": "info@faen.es",
+    "coordinates": {
+      "lat": 43.3133868,
+      "lon": -5.94192
+    }
   },
   {
     "name": "Bizkaiko Behatokia",
@@ -6681,7 +6817,11 @@
     "type": "publico",
     "website": "https://www.visitmadrid.es/observatorio-turistico-comunidad-madrid",
     "is_active": "Sí",
-    "email": "No disponible"
+    "email": "No disponible",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Regional de Seguridad del Paciente",
@@ -6813,7 +6953,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible",
-    "from_date": "Más de 10 años (estaciones desde 1990)"
+    "from_date": "Más de 10 años (estaciones desde 1990)",
+    "coordinates": {
+      "lat": 42.61946,
+      "lon": -7.863112
+    }
   },
   {
     "name": "Observatorio forestal",
@@ -6859,7 +7003,11 @@
         "url": "https://www.madrid.es/portales/munimadrid/es/Inicio/Actividad-economica-y-hacienda/Observatorio-economico/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatorio Municipal contra la LGTBIfobia (Madrid)",
@@ -6869,7 +7017,11 @@
     "type": "publico",
     "website": "https://www.madrid.es/portales/munimadrid/es/Inicio/Buscador/Observatorio-Municipal-contra-la-LGTBIfobia/",
     "is_active": "Sí",
-    "from_date": "2021-12-28"
+    "from_date": "2021-12-28",
+    "coordinates": {
+      "lat": 40.416782,
+      "lon": -3.703507
+    }
   },
   {
     "name": "Observatori Metropolità de l’Habitatge de Barcelona (O-HB)",
@@ -6884,7 +7036,11 @@
     "type": "publico",
     "website": "https://www.ohb.cat/",
     "is_active": "Sí",
-    "from_date": "2017"
+    "from_date": "2017",
+    "coordinates": {
+      "lat": 41.3825802,
+      "lon": 2.177073
+    }
   },
   {
     "name": "Observatori Social Barcelona",
@@ -6912,7 +7068,11 @@
         "url": "https://www.bilbaoekintza.eus/conocenos/areas-de-accion/observatorio"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 43.2630018,
+      "lon": -2.9350039
+    }
   },
   {
     "name": "Observatorio del Plan Estratégico de Sevilla 2030",
@@ -6945,7 +7105,11 @@
         "url": "https://climaienergia.com/es/observatori/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 39.4697065,
+      "lon": -0.3763353
+    }
   },
   {
     "name": "Observatorio de Salud Urbana de València",
@@ -6985,7 +7149,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2008"
+    "from_date": "2008",
+    "coordinates": {
+      "lat": 41.6521807,
+      "lon": -4.728605
+    }
   },
   {
     "name": "Observatorio Municipal de Inmigración (Valladolid)",
@@ -7003,7 +7171,11 @@
       }
     ],
     "is_active": "Sí",
-    "from_date": "2006"
+    "from_date": "2006",
+    "coordinates": {
+      "lat": 41.6521807,
+      "lon": -4.728605
+    }
   },
   {
     "name": "Observatorio Municipal de Estadística (Zaragoza)",
@@ -7018,7 +7190,11 @@
         "url": "https://www.zaragoza.es/sede/portal/observatorio/"
       }
     ],
-    "is_active": "Sí"
+    "is_active": "Sí",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Cátedra de Territorio, Sociedad y Visualización Geográfica (Zaragoza)",
@@ -7028,7 +7204,11 @@
     "type": "mixto",
     "website": "https://www.zaragoza.es/sede/portal/participacion/catedra/territorio/",
     "is_active": "Sí",
-    "from_date": "2016"
+    "from_date": "2016",
+    "coordinates": {
+      "lat": 41.6521342,
+      "lon": -0.8809428
+    }
   },
   {
     "name": "Observatorio de Vivienda de Leganés",
@@ -7075,7 +7255,11 @@
     "scope": "andalucia",
     "type": "mixto",
     "is_active": "No",
-    "from_date": "Anunciado"
+    "from_date": "Anunciado",
+    "coordinates": {
+      "lat": 37.3399964,
+      "lon": -4.5811614
+    }
   },
   {
     "name": "Observatorio para el Impulso Demográfico",
@@ -7099,7 +7283,11 @@
     "parents": ["Diputación de Segovia"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia"
+    "website": "https://www.dipsegovia.es/noticias/-/asset_publisher/1xkM/content/la-diputaci%25C3%25B3n-de-segovia-lanza-la-web-oficial-de-la-agenda-rural-sostenible-de-la-provincia",
+    "coordinates": {
+      "lat": 40.9481192,
+      "lon": -4.1172101
+    }
   },
   {
     "name": "Observatori de la Qualitat de l'Aire del Camp de Tarragona (OQACT)",
@@ -7107,7 +7295,11 @@
     "parents": ["Institut Cerdà", "Repsol", "AEQT"],
     "scope": "cataluna",
     "type": "mixto",
-    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/"
+    "website": "https://www.icerda.org/observatori-aire-tarragona/presentacio-de-la-4a-edicio-de-lobservatori-de-la-qualitat-de-laire/",
+    "coordinates": {
+      "lat": 41.1172364,
+      "lon": 1.2546057
+    }
   },
   {
     "name": "OTIGRAN (Observatorio Turístico de Gran Canaria)",
@@ -7325,7 +7517,11 @@
     "parents": ["Diputación de Segovia"],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica"
+    "website": "https://www.dipsegovia.es/la-institucion/servicios/plan-de-recuperaci%C3%B3n-transformaci%C3%B3n-y-resiliencia-fondos-next-generation/planes-de-sostenibilidad-tur%C3%8Dstica",
+    "coordinates": {
+      "lat": 41.4867788,
+      "lon": -3.5219055
+    }
   },
   {
     "name": "Observatorio Local de Sostenibilidad de Albacete (OLSA)",
@@ -7349,7 +7545,11 @@
     ],
     "scope": "provincial",
     "type": "mixto",
-    "website": "https://www.observatorioeconomicosevilla.com/"
+    "website": "https://www.observatorioeconomicosevilla.com/",
+    "coordinates": {
+      "lat": 37.3886303,
+      "lon": -5.9953403
+    }
   },
   {
     "name": "Indicadores de Administración Digital (Ayuntamiento de Madrid)",

--- a/httpdocs/observatories.json
+++ b/httpdocs/observatories.json
@@ -157,7 +157,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://despoblacionguadalajara.es/"
+    "website": "https://despoblacionguadalajara.es/",
+    "coordinates": {
+      "lat": 40.7399963,
+      "lon": -2.50593
+    }
   },
   {
     "description": "Este organismos pretende poner en valor el patrimonio natural-ambiental de los casi 500 ríos de Galicia, que funcionará como un órgano de asesoramiento sobre el estado ambiental, económico, social y cultural de los rios.<br/>No ha sido posible encontrar información sobre si el observatorio está activo o no, tampoco sobre su actividad, si la tuviere.",
@@ -338,7 +342,11 @@
     "parents": ["Ayuntamiento de Fuenlabrada"],
     "scope": "local",
     "type": "publico",
-    "website": "https://cife.ayto-fuenlabrada.es/observatorio-local-empleo-fuenlabrada/"
+    "website": "https://cife.ayto-fuenlabrada.es/observatorio-local-empleo-fuenlabrada/",
+    "coordinates": {
+      "lat": 40.282476,
+      "lon": -3.7923422
+    }
   },
   {
     "name": "Observatorio de la Infancia de Cataluña / Observatori dels Drets dels Infants",
@@ -615,7 +623,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://agrobservex.juntaex.es/"
+    "website": "https://agrobservex.juntaex.es/",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "description": "El Observatorio de Igualdad de la CRTVE vela por el cumplimiento de los compromisos legales en materia de igualdad de la corporación, haciendo un seguimiento de los contenidos de RTVE y garantizando en ellos el respeto a la igualdad entre mujeres y hombres. Su objetivo es que la corporación sea referente en la defensa de la igualdad y la lucha para la erradicación de la violencia contra las mujeres.",
@@ -978,7 +990,11 @@
       {
         "url": "https://startupvalencia.org/es/descarga-informe-observatorio/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "name": "Observatorio Galego de Dinamización Demográfica",
@@ -1028,7 +1044,11 @@
     "is_active": "No",
     "name": "Observatorio Nacional contra el Despoblamiento",
     "parents": ["Gobierno de Cantabria", "Ayuntamiento de Valderredible"],
-    "scope": "estatal"
+    "scope": "estatal",
+    "coordinates": {
+      "lat": 42.8564085,
+      "lon": -3.9708898
+    }
   },
   {
     "docs": [
@@ -1588,7 +1608,11 @@
     "description": "El Observatorio Extremeño de las TIC es una plataforma que recopila, analiza y difunde información sobre el uso de las tecnologías de la información y la comunicación (TIC) en Extremadura. La información que se comparte, pretende ayudar a las personas lectoras a comprender el histórico y la situación actual de la región extremeña respecto a las TIC y generar una visión completa de hacia dónde evoluciona nuestra región en materia digital y tecnológica.",
     "scope": "extremadura",
     "type": "publico",
-    "website": "https://extremaduradigital.org/"
+    "website": "https://extremaduradigital.org/",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio Agrario",
@@ -1624,7 +1648,11 @@
     "type": "publico",
     "email": "info@obsevatoriofiex.es",
     "website": "https://observatoriofiex.es/observatorio-fiex/",
-    "description": "Para el estudio y análisis de la realidad social de las familias extremeñas, junto con el asesoramiento a los poderes públicos en relación a las políticas de apoyo a estas familias"
+    "description": "Para el estudio y análisis de la realidad social de las familias extremeñas, junto con el asesoramiento a los poderes públicos en relación a las políticas de apoyo a estas familias",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Derechos Digitales",
@@ -1638,7 +1666,11 @@
     "name": "Observatorio para la Convivencia Escolar de Extremadura",
     "scope": "extremadura",
     "website": "https://www.educarex.es/convivencia/observatorio-convivencia-escolar-02.html",
-    "parents": ["Secretaría General de Educación"]
+    "parents": ["Secretaría General de Educación"],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Prevención de Riesgos Laborales de la Comunidad Autónoma de la Región de Murcia",
@@ -1649,7 +1681,11 @@
   },
   {
     "name": "Observatorio de Turismo de Extremadura",
-    "scope": "extremadura"
+    "scope": "extremadura",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio Extremeño de la Cultura",
@@ -1698,7 +1734,11 @@
         "name": "Difusión sobre la calificación e inscripción RSE (nota en ExtremaduraEmpresarial)",
         "url": "https://www.extremaduraempresarial.es/2025/05/02/que-beneficios-aporta-la-calificacion-como-empresa-socialmente-responsable-de-extremadura/"
       }
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio sobre Drogas de la Región de Murcia",
@@ -2151,7 +2191,11 @@
         "name": "¿Cuáles son las experiencias de discriminación de las personas migrantes en Tenerife?"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 28.4857715,
+      "lon": -16.3159422
+    }
   },
   {
     "name": "Observatorio de Coyuntura Industrial",
@@ -2185,7 +2229,11 @@
     ],
     "is_active": "Sí",
     "email": "info@ikuspegi.eus",
-    "from_date": "2004"
+    "from_date": "2004",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Observatorio Turístico de la Provincia de Sevilla",
@@ -2227,7 +2275,11 @@
     "name": "Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura",
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://administracion.gob.es/pagFront/espanaAdmon/directorioOrganigramas/fichaUnidadOrganica.htm?idUnidOrganica=138480&origenUO=comunidadesAutonomas&volver=volverFicha&imprimir=1"
+    "website": "https://administracion.gob.es/pagFront/espanaAdmon/directorioOrganigramas/fichaUnidadOrganica.htm?idUnidOrganica=138480&origenUO=comunidadesAutonomas&volver=volverFicha&imprimir=1",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "description": "El Observatorio de Precios es una herramienta de seguimiento y análisis de los precios en origen de los principales productos agrícolas y ganaderos de Castilla y León.\n\nSeguirlos y analizarlos con el máximo rigor y transparencia hará posible prever y detectar a tiempo las oscilaciones y desequilibrios entre la oferta y la demanda, lo que permitirá tomar las decisiones más correctas para mantener el equilibrio entre todos sus componentes y, en último término, podrá evitar que los consumidores asuman un sobrecoste injustificado y contribuirá a que los agricultores y ganaderos obtengan una retribución justa por sus producciones.\n\nEl Observatorio muestra los precios en origen de aquellos productos agrícolas y ganaderos en los que Castilla y León ocupa una posición relevante en el ámbito nacional por ser una de las principales productoras o por la calidad diferenciada de su producción, sin perjuicio de que paulatinamente puede ofrecerse información sobre más productos.",
@@ -2242,7 +2294,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://agriculturaganaderia.jcyl.es/web/es/estadistica-informacion-agraria/observatorio.html#:~:text=El%20Observatorio%20muestra%20los%20precios%20en%20origen%20de,que%20paulatinamente%20puede%20ofrecerse%20informaci%C3%B3n%20sobre%20m%C3%A1s%20productos."
+    "website": "https://agriculturaganaderia.jcyl.es/web/es/estadistica-informacion-agraria/observatorio.html#:~:text=El%20Observatorio%20muestra%20los%20precios%20en%20origen%20de,que%20paulatinamente%20puede%20ofrecerse%20informaci%C3%B3n%20sobre%20m%C3%A1s%20productos.",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatorio Administración Electrónica Ayuntamiento de Ciudad Real",
@@ -2252,7 +2308,11 @@
     "scope": "local",
     "from_date": "Octubre 2025",
     "parents": ["Ayuntamiento de Ciudad Real"],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 38.9597348,
+      "lon": -3.8828744
+    }
   },
   {
     "name": "Observatorio Vasco LGTBI+",
@@ -2599,7 +2659,11 @@
     ],
     "scope": "local",
     "type": "mixto",
-    "website": "alasacoruna.org/observatorio-corunes-contra-la-lgtbifobia/"
+    "website": "alasacoruna.org/observatorio-corunes-contra-la-lgtbifobia/",
+    "coordinates": {
+      "lat": 43.3709703,
+      "lon": -8.3959425
+    }
   },
   {
     "description": "Para <q>la obtención y análisis sistemático de información y datos objetivos del sector necesario para conocer su historia, estructura, impacto económico y realidad actual del arte jondo, así como una herramienta para su evaluación</q>.",
@@ -3316,7 +3380,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://www.obcp.es"
+    "website": "https://www.obcp.es",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "impulsar el espíritu comercial y transmitirlo a todo el colectivo empresarial de la provincia de Alicante y su hinterland.\n\nse crea este Observatorio Comercial con el que se persigue producir, recopilar y evaluar información referente a la actividad económica y logística de la provincia, así como de los flujos de transporte marítimo exterior, con el fin de poder ofrecer un servicio del Puerto de Alicante más atractivo para el tejido empresarial y acorde a sus necesidades\n\nAutoridad Portuaria de Alicante\r\nComunidad Portuaria\r\nCámara de Comercio\r\nComunidad Empresarial\r\nComunidad Marítima\r\nComunidad Logística Portuaria",
@@ -3382,7 +3450,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://comercio.castillalamancha.es/observatorio-comercio"
+    "website": "https://comercio.castillalamancha.es/observatorio-comercio",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "docs": [
@@ -3471,7 +3543,11 @@
       "Junta de Castilla-La Mancha"
     ],
     "scope": "castilla_la_mancha",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "L’Observatori es configura com un òrgan tècnic adscrit al Departament de Justícia, Drets i Memòria i dependent del Centre d’Estudis Jurídics i Formació Especialitzada, que n’aportarà la infraestructura i el suport administratiu, tècnic i logístic necessari perquè pugui dur a terme la seva activitat, i està dotat pressupostàriament amb fons del Pacte d’Estat contra la Violència de Gènere.\n\nÉs un repte pel CEJFE posar en marxa aquest Observatori i fer-ne d’ell un instrument que ajudi a millorar la resposta de l’administració de justícia i de l’execució penal davant el fenomen de les violències masclistes, amb la finalitat d’aproximar aquest coneixement a la lluita per a la seva erradicació. Així, l’Observatori constitueix un fòrum d'anàlisi, reflexió, debat, participació i proposta d'actuació en matèries relacionades amb la violència masclista a Catalunya.\n\nTotes les activitats gestionades per l’Observatori estan finançades a càrrec del crèdits rebuts del Ministeri d’Igualtat (Secretaria d’Estat d’Igualtat i contra la Violència de Gènere).",
@@ -3572,7 +3648,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://plagas.itacyl.es"
+    "website": "https://plagas.itacyl.es",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "description": "El Observatorio dispondrá de una página en la web del Colegio de arquitectos [www.coacmto.com](https://coacmto.com/coacmto-sede-y-horario-colegio-oficial-de-arquitectos-castilla-la-mancha) donde se informará de las actividades, noticias o jornadas que se programen y dispondrá de un sencillo formulario de inscripción abierto a ciudadanos, profesionales, asociaciones, entidades públicas o privadas que estén interesados en participar en esta iniciativa.",
@@ -3584,7 +3664,11 @@
       "Empresa Municipal de Suelo y Vivienda de Toledo"
     ],
     "scope": "castilla_la_mancha",
-    "website": "https://coacmto.com/observatorio-vivienda-colaborativa-toledo"
+    "website": "https://coacmto.com/observatorio-vivienda-colaborativa-toledo",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Recoge infracciones y casos de malas prácticas en la minería a partir de las denuncias realizadas por la ciudadanía y los colectivos sociales.",
@@ -3653,7 +3737,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://obafi.es"
+    "website": "https://obafi.es",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "name": "Observatorio contra la Soledad No Deseada (SND)",
@@ -3677,7 +3765,11 @@
         "url": "https://trescantosplus.es/ii-sesion-del-observatorio-contra-la-soledad-no-deseada-en-las-personas-mayores/"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 40.6012354,
+      "lon": -3.7038475
+    }
   },
   {
     "description": "El IPEX, como organismo dependiente de la Consejería de Economía, Empresas y Empleo, encargado de la promoción internacional de las empresas de Castilla-La Mancha, pone en marcha esta oficina de atención virtual que atiende a las empresas de la región para resolver tus dudas sobre el Brexit.",
@@ -3690,7 +3782,11 @@
     ],
     "scope": "estatal",
     "type": "publico",
-    "website": "https://ipex.es/global-news/articulos-de-interes/observatorio-de-castilla-la-mancha-sobre-el-brexit/"
+    "website": "https://ipex.es/global-news/articulos-de-interes/observatorio-de-castilla-la-mancha-sobre-el-brexit/",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "El Observatorio de la Discapacidad de Rivas Vaciamadrid nació en el 2009 como una iniciativa conjunta entre la corporación local y las diferentes entidades y asociaciones del municipio que trabajan con, para y por las personas con discapacidad y dependencia. Entre sus objetivos se encuentran: Promover la plena participación de las personas con discapacidades en la vida ciudadana. Velar y colaborar en el desarrollo de las políticas y actuaciones en materia de protección y promoción de la calidad de vida de las personas con discapacidades, por parte de todas las Administraciones Públicas. Hacer visible en el municipio las necesidades y las capacidades de las personas con algún tipo de discapacidad. Su principal función se centra son conocer la realidad de la situación de estas personas, crear espacios de participación social en los que se recojan las propuestas e inquietudes, y se promuevan iniciativas que atiendan las necesidades planteadas.",
@@ -3706,7 +3802,11 @@
     "parents": ["Ayuntamiento de Rivas-Vaciamadrid"],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.rivasciudad.es/organos-de-participacion-ciudadana/foros-y-observatorios-locales/observatorio-municipal-de-personas-con-discapacidades/"
+    "website": "https://www.rivasciudad.es/organos-de-participacion-ciudadana/foros-y-observatorios-locales/observatorio-municipal-de-personas-con-discapacidades/",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    }
   },
   {
     "description": "El Observatorio de la Ciudad, instrumento de evaluación de la gestión municipal y de difusión e información de sus resultados a la ciudadanía, tiene como finalidad impulsar de forma institucional la evaluación de la gestión municipal, la rendición de cuentas y la efectividad de los principios de transparencia y participación, teniendo en cuenta especialmente la percepción que tiene la ciudadanía de la calidad de los servicios municipales.",
@@ -3729,7 +3829,11 @@
       "Junta de Castilla-La Mancha"
     ],
     "scope": "castilla_la_mancha",
-    "type": "publico"
+    "type": "publico",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Elaboración de propuestas para la mejora de la convivencia.",
@@ -3742,7 +3846,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://www.educa.jccm.es/educa-jccm/cm/educa_jccm/tkContent?idContent=62664&locale=en_UK&textOnly=false"
+    "website": "https://www.educa.jccm.es/educa-jccm/cm/educa_jccm/tkContent?idContent=62664&locale=en_UK&textOnly=false",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Desde la Oficina Verde de la Universidad de Burgos (UbuVerde), y con la colaboración de Sodebur se ha creado un Observatorio por la Repoblacción Rural de castilla y León, cuyo objetivo es informar de la actualidad, analizar y determinar la evolución de la realidad demográfica en el medio rural de Castilla y león. Además, sensibilizar a la población y hacer ver la realidad de esta situación.\n\n- Oficina Verde de la Universidad de Burgos (UbuVerde)\r\n- Sodebur (Sociedad para el desarrollo de la povincia de Burgos)",
@@ -3757,7 +3865,11 @@
     ],
     "scope": "provincial",
     "type": "publico",
-    "website": "https://www.ubu.es/ubuverde/repoblacion-rural/observatorio-por-la-repoblacion-rural"
+    "website": "https://www.ubu.es/ubuverde/repoblacion-rural/observatorio-por-la-repoblacion-rural",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "email": "smartcatalonia@gencat.cat",
@@ -3802,7 +3914,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://empleoyformacion.castillalamancha.es/observatorio"
+    "website": "https://empleoyformacion.castillalamancha.es/observatorio",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "Mantenimiento de un sistema de indicadores que permita el seguimiento de la evolución del consumo de drogas en Castilla-La Mancha.",
@@ -3825,7 +3941,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://sanidad.castillalamancha.es/ciudadanos/observatorio-de-drogodependencias-clm/que-es-el-od"
+    "website": "https://sanidad.castillalamancha.es/ciudadanos/observatorio-de-drogodependencias-clm/que-es-el-od",
+    "coordinates": {
+      "lat": 39.4177902,
+      "lon": -2.6232332
+    }
   },
   {
     "description": "L'Observatori-Centre d'Estudis és un instrument de suport a la presa de decisions per tal que aquestes adquireixin un caràcter més estratègic. També és un element de suport per als tècnics que treballen en els diversos àmbits locals. L’existència d’un Centre d’Estudis permet l' anàlisi prèvia a l’hora de planificar o dissenyar actuacions facilitant que es pugui respondre millor a les necessitats reals del territori o les actuacions a desenvolupar des del propi Consell Comarcal. L’Observatori actua com a banc de dades, per tal d’aglutinar i guardar la informació relativa als municipis així com també fer difusió o recollir dades d’àmbits superiors amb incidència en l’àmbit local.\n\nCarta de Serveis Observatori-Centre d'Estudis => [ENLACE](https://www.vallesoriental.cat/ambits/lobservatori-centre-destudis/carta-de-serveis/)\n\nObservatori-centre d’estudis del Vallès Oriental ( otro enlace )\n\nhttps://www.vallesoriental.cat/2028-el-consell/guia-de-serveis-i-cartes-de-servei/desenvolupament-socioeconomic/observatori-centre-destudis-del-valles-oriental.html",
@@ -3904,7 +4024,11 @@
     "parents": ["Junta de Castilla y León"],
     "scope": "castilla_y_leon",
     "type": "publico",
-    "website": "https://www.observatoriotransformacion.com"
+    "website": "https://www.observatoriotransformacion.com",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "docs": [
@@ -3958,7 +4082,11 @@
     ],
     "scope": "castilla_la_mancha",
     "type": "publico",
-    "website": "https://observatoriolgtbiclm.com"
+    "website": "https://observatoriolgtbiclm.com",
+    "coordinates": {
+      "lat": 40.7399963,
+      "lon": -2.50593
+    }
   },
   {
     "docs": [
@@ -4053,7 +4181,11 @@
         "name": "Informes Anuales de Transformación Urbana (todavía no publicado)"
       }
     ],
-    "is_active": "Si"
+    "is_active": "Si",
+    "coordinates": {
+      "lat": 37.3397709,
+      "lon": -5.8408396
+    }
   },
   {
     "description": "Observa los precios de venta al público y trata de identificar posibles subidas injustificadas de precios.",
@@ -4532,7 +4664,11 @@
       "Generalitat Valenciana",
       "Ministerio de Trabajo y Economía Social"
     ],
-    "website": "https://observatorimarinaalta.org"
+    "website": "https://observatorimarinaalta.org",
+    "coordinates": {
+      "lat": 38.7567857,
+      "lon": -0.0044809
+    }
   },
   {
     "name": "Observatorio de la Formación en el Transporte por Carretera",
@@ -4621,7 +4757,11 @@
     ],
     "scope": "comunidad_valenciana",
     "type": "publico",
-    "website": "https://mediambient.gva.es/es/web/agua/novedades/-/asset_publisher/cYq5fnvdHYwT/content/observatorio-ciudadano-del-agua-de-la-comunitat-valenciana"
+    "website": "https://mediambient.gva.es/es/web/agua/novedades/-/asset_publisher/cYq5fnvdHYwT/content/observatorio-ciudadano-del-agua-de-la-comunitat-valenciana",
+    "coordinates": {
+      "lat": 39.6819591,
+      "lon": -0.7654406
+    }
   },
   {
     "is_active": "None",
@@ -5257,7 +5397,11 @@
     ],
     "scope": "autonómico",
     "type": "publico",
-    "website": "https://www.caib.es/sites/observatorideltreball/es/portada-10648/"
+    "website": "https://www.caib.es/sites/observatorideltreball/es/portada-10648/",
+    "coordinates": {
+      "lat": 39.613432,
+      "lon": 2.8829185
+    }
   },
   {
     "description": "Sus actividades incluyen la reunión periódica de sus miembros sobre temas particulares relativos al desarrollo de la industria en España, la realización de estudios de caso y conferencias de expertos, así como la elaboración de un informe anual sobre el estado de las finanzas islámicas en España.",
@@ -5481,7 +5625,11 @@
     ],
     "scope": "local",
     "type": "publico",
-    "website": "https://www.oag-fundacion.org/"
+    "website": "https://www.oag-fundacion.org/",
+    "coordinates": {
+      "lat": 28.4857715,
+      "lon": -16.3159422
+    }
   },
   {
     "from_date": "2011",
@@ -5920,7 +6068,11 @@
     "scope": "extremadura",
     "parents": ["Junta de Extremadura"],
     "is_active": "Si",
-    "description": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura es un servicio público de información y análisis del mercado de trabajo en Extremadura, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación."
+    "description": "El Observatorio para la Innovación y la Prospectiva del Mercado de Trabajo en Extremadura es un servicio público de información y análisis del mercado de trabajo en Extremadura, que tiene como objetivo proporcionar datos e informes que ayuden a la toma de decisiones en materia de empleo y formación.",
+    "coordinates": {
+      "lat": 39.1748426,
+      "lon": -6.1529891
+    }
   },
   {
     "name": "Observatorio de Resultados del Servicio Murciano de Salud",
@@ -6298,7 +6450,11 @@
     ],
     "is_active": "Sí",
     "email": "No disponible. Se ofrece un formulario de contacto general.",
-    "from_date": "2018 (Copyright del sitio web)"
+    "from_date": "2018 (Copyright del sitio web)",
+    "coordinates": {
+      "lat": 41.55005,
+      "lon": -5.1387401
+    }
   },
   {
     "name": "Observatori del Patrimoni Natural i la Biodiversitat",
@@ -6690,7 +6846,11 @@
     "scope": "local",
     "type": "publico",
     "is_active": "No",
-    "from_date": "2023-01-11 (Anunciado/En creación)"
+    "from_date": "2023-01-11 (Anunciado/En creación)",
+    "coordinates": {
+      "lat": 40.3536054,
+      "lon": -3.5310879
+    }
   },
   {
     "name": "Observatorio del Impacto Social de los Algoritmos (OBISAL)",
@@ -6755,7 +6915,11 @@
     "parents": ["Cabildo de Gran Canaria", "Turismo de Gran Canaria"],
     "scope": "canarias",
     "type": "publico",
-    "website": "https://observatorioturisticograncanaria.com/"
+    "website": "https://observatorioturisticograncanaria.com/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Euskal Herriko Giza Eskubideen Behatokia (GEBEHATOKIA)",
@@ -6795,7 +6959,11 @@
     "parents": ["Gobierno Vasco", "Universidad del País Vasco (UPV/EHU)"],
     "scope": "pais_vasco",
     "type": "publico",
-    "website": "https://eeb-ove.eus/observatorio/"
+    "website": "https://eeb-ove.eus/observatorio/",
+    "coordinates": {
+      "lat": 42.9911816,
+      "lon": -2.5543023
+    }
   },
   {
     "name": "Behatokia (Gizarte Aurreikuspen Osagarria)",
@@ -6885,7 +7053,11 @@
     "description": "Observatorio para el seguimiento/impulso de la accesibilidad en Gran Canaria. <a href=\"https://www.grancanariaaccesible.info/observatorio/\">Sitio web</a>.",
     "scope": "canarias",
     "type": "publico",
-    "website": "https://www.grancanariaaccesible.info/observatorio/"
+    "website": "https://www.grancanariaaccesible.info/observatorio/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio del Comercio de Gran Canaria",
@@ -6893,7 +7065,11 @@
     "parents": ["Cámara de Comercio de Gran Canaria"],
     "scope": "canarias",
     "type": "mixto",
-    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/"
+    "website": "https://www.camaragrancanaria.org/comercio/observatorio-del-comercio/",
+    "coordinates": {
+      "lat": 27.9580004,
+      "lon": -15.6062305
+    }
   },
   {
     "name": "Observatorio de Prospectiva para la Gobernanza Insular",

--- a/httpdocs/stylesheets/observatoriospublicos.css
+++ b/httpdocs/stylesheets/observatoriospublicos.css
@@ -112,3 +112,27 @@ dialog h3 {
   text-transform: capitalize;
   margin: 0 0.25rem;
 }
+
+#observatories-map {
+  height: clamp(18rem, 50vh, 32rem);
+  margin: 1em 0 0.5em;
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: 0.75em;
+  overflow: hidden;
+  background: var(--pico-muted-background-color);
+}
+
+#observatories-map-stats {
+  display: block;
+  color: var(--pico-muted-color);
+  margin-bottom: 1em;
+}
+
+#observatories-map .leaflet-container {
+  font: inherit;
+}
+
+#observatories-map .leaflet-popup-content ul {
+  margin: 0.5em 0 0;
+  padding-left: 1.25em;
+}

--- a/httpdocs/stylesheets/observatoriospublicos.css
+++ b/httpdocs/stylesheets/observatoriospublicos.css
@@ -173,6 +173,13 @@ dialog h3 {
   padding-left: 1.25em;
 }
 
+#observatories-map .map-popup-list {
+  max-height: clamp(6rem, 25vh, 12rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.25rem;
+}
+
 #observatories-map .map-pin-wrapper {
   background: transparent;
   border: 0;

--- a/httpdocs/stylesheets/observatoriospublicos.css
+++ b/httpdocs/stylesheets/observatoriospublicos.css
@@ -172,3 +172,32 @@ dialog h3 {
   margin: 0.5em 0 0;
   padding-left: 1.25em;
 }
+
+#observatories-map .map-pin-wrapper {
+  background: transparent;
+  border: 0;
+}
+
+#observatories-map .map-pin {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #111;
+  color: white;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+#observatories-map .map-pin--cluster {
+  background: var(--pico-primary);
+}
+
+#observatories-map .map-pin span {
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0 0.25em;
+}

--- a/httpdocs/stylesheets/observatoriospublicos.css
+++ b/httpdocs/stylesheets/observatoriospublicos.css
@@ -132,6 +132,42 @@ dialog h3 {
   font: inherit;
 }
 
+#observatories-map .leaflet-control-zoom a[role='button'] {
+  /* PicoCSS aplica estilos a [role=button] que rompen los controles +/-. */
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  display: block;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+}
+
+#observatories-map .leaflet-control-zoom-in[role='button'],
+#observatories-map .leaflet-control-zoom-out[role='button'] {
+  font:
+    bold 18px 'Lucida Console',
+    Monaco,
+    monospace;
+  text-indent: 1px;
+}
+
+#observatories-map .leaflet-touch .leaflet-control-zoom a[role='button'] {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+}
+
+#observatories-map .leaflet-touch .leaflet-control-zoom-in[role='button'],
+#observatories-map .leaflet-touch .leaflet-control-zoom-out[role='button'] {
+  font-size: 22px;
+}
+
+#observatories-map .leaflet-control-zoom a[role='button']:focus-visible {
+  outline: 2px solid var(--pico-primary-focus);
+  outline-offset: 1px;
+}
+
 #observatories-map .leaflet-popup-content ul {
   margin: 0.5em 0 0;
   padding-left: 1.25em;


### PR DESCRIPTION

<img width="1930" height="955" alt="image" src="https://github.com/user-attachments/assets/bfdab4c2-92c3-4ecb-9b81-3cc988bd66c9" />


## Resumen

- Añade un mapa interactivo con todos los observatorios con coordenadas (Leaflet + OpenStreetMap).
- Pines numerados: el número indica cuántos observatorios hay en ese punto o en el cluster actual.
- Agrupación simple por zoom (merge al alejar, split al acercar) sin dependencias extra (sin plugins de clustering).
- Zoom: pinch (trackpad/pantalla táctil) y Ctrl/Cmd+scroll; el scroll normal de la página no hace zoom.
- Ajustes CSS para que los controles +/− de Leaflet se rendericen correctamente con PicoCSS.

## Pruebas

1. `npm run serve`
2. Abrir `http://localhost:8080` (o el puerto que asigne live-server si `8080` está ocupado).
3. Comprobar: mapa visible, pines numerados, popup correcto, zoom-in/out agrupa y desagrupa, y los botones +/− se ven bien.
